### PR TITLE
Pulumi プロジェクトパスの命名規則を統一

### DIFF
--- a/ansible/roles/jenkins_agent/tasks/deploy.yml
+++ b/ansible/roles/jenkins_agent/tasks/deploy.yml
@@ -51,12 +51,12 @@
         name: pulumi_helper
         tasks_from: init_stack
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/agent"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
         stack_name: "{{ env_name }}"
     
     - name: Configure agent stack
       ansible.builtin.shell: |
-        cd {{ pulumi_path }}/agent
+        cd {{ pulumi_path }}/jenkins-agent
         source {{ scripts_dir }}/aws-env.sh 
         eval $({{ scripts_dir }}/aws-env.sh)
         
@@ -80,7 +80,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/network"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-network"
         output_name: "vpcId"
         mock_output: "mock-vpc-id-for-check-mode"
     
@@ -93,7 +93,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/security"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-security"
         output_name: "jenkinsAgentSecurityGroupId"
         mock_output: "mock-agent-sg-id"
     
@@ -114,7 +114,7 @@
         name: pulumi_helper
         tasks_from: preview
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/agent"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
     
     # Pulumiデプロイ
     - name: Deploy agent stack
@@ -122,7 +122,7 @@
         name: pulumi_helper
         tasks_from: deploy
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/agent"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
     
     # デプロイ後に少し待機してスタックが完全に更新されるのを待つ
     - name: Wait for stack outputs to be available
@@ -136,7 +136,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/agent"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
         output_name: "spotFleetRequestId"
         mock_output: "mock-spot-fleet-request-id"
     
@@ -149,7 +149,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/agent"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
         output_name: "launchTemplateId"
         mock_output: "mock-launch-template-id"
     

--- a/ansible/roles/jenkins_config/tasks/setup.yml
+++ b/ansible/roles/jenkins_config/tasks/setup.yml
@@ -37,7 +37,7 @@
     name: pulumi_helper
     tasks_from: get_outputs
   vars:
-    pulumi_project_path: "{{ pulumi_path }}/controller"
+    pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
     output_name: "jenkinsInstanceId"
     mock_output: "mock-jenkins-instance-id"
   when: jenkins_instance_id is not defined or jenkins_instance_id == ""
@@ -64,7 +64,7 @@
     name: pulumi_helper
     tasks_from: get_outputs
   vars:
-    pulumi_project_path: "{{ pulumi_path }}/storage"
+    pulumi_project_path: "{{ pulumi_path }}/jenkins-storage"
     output_name: "efsFileSystemId"
     mock_output: "mock-efs-id"
   when: efs_file_system_id is not defined or efs_file_system_id == ""

--- a/ansible/roles/jenkins_controller/tasks/deploy.yml
+++ b/ansible/roles/jenkins_controller/tasks/deploy.yml
@@ -38,12 +38,12 @@
         name: pulumi_helper
         tasks_from: init_stack
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/controller"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
         stack_name: "{{ env_name }}"
     
     - name: Configure controller stack
       ansible.builtin.shell: |
-        cd {{ pulumi_path }}/controller
+        cd {{ pulumi_path }}/jenkins-controller
         source {{ scripts_dir }}/aws-env.sh 
         eval $({{ scripts_dir }}/aws-env.sh)
         
@@ -75,7 +75,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/network"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-network"
         output_name: "vpcId"
         mock_output: "mock-vpc-id-for-check-mode"
     
@@ -88,7 +88,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/security"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-security"
         output_name: "jenkinsSecurityGroupId"
         mock_output: "mock-jenkins-sg-id"
     
@@ -101,7 +101,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/storage"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-storage"
         output_name: "efsFileSystemId"
         mock_output: "mock-efs-id"
     
@@ -114,7 +114,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/loadbalancer"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-loadbalancer"
         output_name: "blueTargetGroupArn"
         mock_output: "mock-blue-tg-arn"
     
@@ -137,7 +137,7 @@
         name: pulumi_helper
         tasks_from: preview
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/controller"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
     
     # Pulumiデプロイ
     - name: Deploy controller stack
@@ -145,7 +145,7 @@
         name: pulumi_helper
         tasks_from: deploy
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/controller"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
     
     # デプロイ後に少し待機してスタックが完全に更新されるのを待つ
     - name: Wait for stack outputs to be available
@@ -159,7 +159,7 @@
         name: pulumi_helper
         tasks_from: get_outputs
       vars:
-        pulumi_project_path: "{{ pulumi_path }}/controller"
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
         output_name: "jenkinsInstanceId"
         mock_output: "mock-jenkins-instance-id"
     


### PR DESCRIPTION
このPRは、Ansible の設定ファイル内の Pulumi プロジェクトパスの命名規則を統一するものです。

### 変更内容
- 全ての Pulumi プロジェクトパスを明確に識別できるよう、接頭辞「jenkins-」を追加しました
  - `agent` → `jenkins-agent`
  - `controller` → `jenkins-controller`
  - `network` → `jenkins-network`
  - `security` → `jenkins-security`
  - `storage` → `jenkins-storage`
  - `loadbalancer` → `jenkins-loadbalancer`

### 影響範囲
- `ansible/roles/jenkins_agent/tasks/deploy.yml`
- `ansible/roles/jenkins_config/tasks/setup.yml`
- `ansible/roles/jenkins_controller/tasks/deploy.yml`
