### PR TITLE
Jenkinsの変数定義を整理し、デフォルト値の設定方法を統一

### DIFF
--- a/ansible/playbooks/jenkins_setup_pipeline.yml
+++ b/ansible/playbooks/jenkins_setup_pipeline.yml
@@ -32,6 +32,11 @@
         controller_project_name: "{{ infra.pulumi.controller_project }}"
         agent_project_name: "{{ infra.pulumi.agent_project }}"
         config_project_name: "{{ infra.pulumi.config_project }}"
+        jenkins_version: "{{ version | default(jenkins.version) }}"
+        jenkins_color: "{{ color | default(jenkins.color) }}"
+        recovery_mode: "{{ recovery | default(jenkins.recovery_mode) }}"
+        git_repo: "{{ git_repo | default(jenkins.git.repo) }}"
+        git_branch: "{{ git_branch | default(jenkins.git.branch) }}"
 
   roles:
     - aws_setup
@@ -154,11 +159,6 @@
     - name: Configure Jenkins Controller
       ansible.builtin.include_role:
         name: jenkins_config
-      vars:
-        # 必要な変数を明示的に設定
-        jenkins_version: "{{ jenkins_version | default(jenkins.version) }}"
-        jenkins_color: "{{ jenkins_color | default(jenkins.color) }}"
-        recovery_mode: "{{ recovery_mode | default(jenkins.recovery_mode) }}"
       when: 
         - controller_deployed | default(false) | bool
         - run_config | default(true) | bool

--- a/ansible/roles/jenkins_config/tasks/setup.yml
+++ b/ansible/roles/jenkins_config/tasks/setup.yml
@@ -10,7 +10,7 @@
       - Config Pulumi Project: {{ config_project_name }}
       - Environment: {{ env_name }}
       - Jenkins Instance ID: {{ jenkins_instance_id | default('未設定') }}
-      - Jenkins Color: {{ jenkins_color }}
+      - Jenkins Color: {{ jenkins_color | default('blue') }}
 
 # 既存のSSMドキュメントを削除
 - name: Destroy existing SSM documents with Pulumi


### PR DESCRIPTION
この PR では、Jenkins セットアップ用の Ansible プレイブックとロールにおける変数定義を整理しました。

1. プレイブック冒頭で Jenkins 関連の基本変数（jenkins_version, jenkins_color, recovery_mode, git_repo, git_branch）の定義を追加
2. jenkins_config ロールの呼び出し部分で重複していた変数定義を削除（上部で既に定義済み）
3. setup.yml の Jenkins カラー表示部分にデフォルト値を追加（`jenkins_color | default('blue')`）

これらの変更により、変数定義の場所が一元化され、デフォルト値の設定方法も統一されました。コードの可読性と保守性が向上します。