### PR TITLE
Jenkins インフラ削除機能の追加と Pulumi 認証エラーの修正

### DIFF
--- a/ansible/playbooks/jenkins_teardown_pipeline.yml
+++ b/ansible/playbooks/jenkins_teardown_pipeline.yml
@@ -14,17 +14,9 @@
     scripts_dir: "{{ playbook_dir }}/../../scripts"
     pulumi_path: "{{ playbook_dir }}/../../pulumi"
     # 削除確認フラグ（デフォルトはfalse）
-    confirm_destroy: "{{ confirm | default(false) }}"
+    confirm_destroy: "{{ confirm | default(false) | bool }}"
     # スタック削除フラグ（デフォルトはfalse）
-    remove_stacks: "{{ remove_stacks | default(false) }}"
-    # 個別コンポーネント削除フラグ（デフォルトは全てtrue）
-    tear_config: "{{ tear_config | default(true) | bool }}"
-    tear_agent: "{{ tear_agent | default(true) | bool }}"
-    tear_controller: "{{ tear_controller | default(true) | bool }}"
-    tear_loadbalancer: "{{ tear_loadbalancer | default(true) | bool }}"
-    tear_storage: "{{ tear_storage | default(true) | bool }}"
-    tear_security: "{{ tear_security | default(true) | bool }}"
-    tear_network: "{{ tear_network | default(true) | bool }}"
+    remove_stacks: "{{ remove_stacks | default(false) | bool }}"
   
   pre_tasks:
     # all.yml から変数を読み込む
@@ -44,6 +36,17 @@
         controller_project_name: "{{ infra.pulumi.controller_project }}"
         agent_project_name: "{{ infra.pulumi.agent_project }}"
         config_project_name: "{{ infra.pulumi.config_project }}"
+    
+    # コンポーネント削除フラグの設定（デフォルトは全てtrue）
+    - name: Set component teardown flags
+      ansible.builtin.set_fact:
+        tear_config: "{{ tear_config | default(true) | bool }}"
+        tear_agent: "{{ tear_agent | default(true) | bool }}"
+        tear_controller: "{{ tear_controller | default(true) | bool }}"
+        tear_loadbalancer: "{{ tear_loadbalancer | default(true) | bool }}"
+        tear_storage: "{{ tear_storage | default(true) | bool }}"
+        tear_security: "{{ tear_security | default(true) | bool }}"
+        tear_network: "{{ tear_network | default(true) | bool }}"
 
   roles:
     - aws_setup
@@ -120,7 +123,7 @@
         operation: "destroy"
         remove_stacks: "{{ remove_stacks }}"
       when: tear_agent | bool
-
+    
 
     # 2. Config削除（SSMドキュメント）
     - name: Destroy Jenkins Configuration Resources

--- a/ansible/playbooks/jenkins_teardown_pipeline.yml
+++ b/ansible/playbooks/jenkins_teardown_pipeline.yml
@@ -1,0 +1,204 @@
+---
+# jenkins_teardown_pipeline.yml
+# Jenkins環境のコンポーネントを逆順で削除するプレイブック
+
+- name: Jenkins Infrastructure Teardown Pipeline
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  
+  vars:
+    # 環境名はコマンドラインから指定可能
+    env_name: "{{ env | default('dev') }}"
+    # パスを明示的に定義
+    scripts_dir: "{{ playbook_dir }}/../../scripts"
+    pulumi_path: "{{ playbook_dir }}/../../pulumi"
+    # 削除確認フラグ（デフォルトはfalse）
+    confirm_destroy: "{{ confirm | default(false) }}"
+    # スタック削除フラグ（デフォルトはfalse）
+    remove_stacks: "{{ remove_stacks | default(false) }}"
+    # 個別コンポーネント削除フラグ（デフォルトは全てtrue）
+    tear_config: "{{ tear_config | default(true) | bool }}"
+    tear_agent: "{{ tear_agent | default(true) | bool }}"
+    tear_controller: "{{ tear_controller | default(true) | bool }}"
+    tear_loadbalancer: "{{ tear_loadbalancer | default(true) | bool }}"
+    tear_storage: "{{ tear_storage | default(true) | bool }}"
+    tear_security: "{{ tear_security | default(true) | bool }}"
+    tear_network: "{{ tear_network | default(true) | bool }}"
+  
+  pre_tasks:
+    # all.yml から変数を読み込む
+    - name: Include group_vars/all.yml
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../inventory/group_vars/all.yml"
+        
+    # 必要な変数を設定
+    - name: Set required variables from all.yml
+      ansible.builtin.set_fact:
+        project_name: "{{ infra.project_name }}"
+        aws_region_name: "{{ infra.aws.default_region }}"
+        network_project_name: "{{ infra.pulumi.network_project }}"
+        security_project_name: "{{ infra.pulumi.security_project }}"
+        storage_project_name: "{{ infra.pulumi.storage_project }}"
+        loadbalancer_project_name: "{{ infra.pulumi.loadbalancer_project }}"
+        controller_project_name: "{{ infra.pulumi.controller_project }}"
+        agent_project_name: "{{ infra.pulumi.agent_project }}"
+        config_project_name: "{{ infra.pulumi.config_project }}"
+
+  roles:
+    - aws_setup
+    - pulumi_helper
+    
+  tasks:
+    - name: Check scripts directory exists
+      ansible.builtin.stat:
+        path: "{{ scripts_dir }}"
+      register: scripts_dir_stat
+      no_log: true
+      
+    - name: Fail if scripts directory doesn't exist
+      ansible.builtin.fail:
+        msg: "Scripts directory doesn't exist: {{ scripts_dir }}"
+      when: not scripts_dir_stat.stat.exists
+      
+    - name: Ensure all shell scripts have proper execute permissions
+      ansible.builtin.find:
+        paths: "{{ scripts_dir }}"
+        patterns: "*.sh"
+        recurse: yes
+      register: script_files
+      no_log: true
+      
+    - name: Set execute permissions on shell scripts
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        mode: "0755"
+      loop: "{{ script_files.files }}"
+      register: script_perm_updates
+      no_log: true
+        
+    - name: Display teardown information
+      ansible.builtin.debug:
+        msg: |
+          Jenkins Infrastructure Teardown Pipeline
+          ==================================
+          Project: {{ project_name }}
+          Environment: {{ env_name }}
+          AWS Region: {{ aws_region_name }}
+          
+          Components to destroy:
+          - Config: {{ tear_config }}
+          - Agent: {{ tear_agent }}
+          - Controller: {{ tear_controller }}
+          - LoadBalancer: {{ tear_loadbalancer }}
+          - Storage: {{ tear_storage }}
+          - Security: {{ tear_security }}
+          - Network: {{ tear_network }}
+          
+          Remove Pulumi stacks: {{ remove_stacks }}
+          
+          WARNING: This will destroy your Jenkins infrastructure!
+          Use --extra-vars "confirm=true" to proceed.
+    
+    # 削除確認（confirm=trueが指定されていない場合は中断）
+    - name: Verify teardown confirmation
+      ansible.builtin.fail:
+        msg: "Teardown not confirmed. Please run with --extra-vars 'confirm=true' to proceed."
+      when: not confirm_destroy | bool
+    
+    # 確認後にプロセスを継続
+    - name: Confirm teardown process
+      ansible.builtin.debug:
+        msg: "Teardown confirmed. Proceeding with infrastructure destruction..."
+      when: confirm_destroy | bool
+    
+    # 1. エージェント削除
+    - name: Destroy Agent Infrastructure
+      ansible.builtin.include_role:
+        name: jenkins_agent
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_agent | bool
+
+
+    # 2. Config削除（SSMドキュメント）
+    - name: Destroy Jenkins Configuration Resources
+      ansible.builtin.include_role:
+        name: jenkins_config
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_config | bool
+    
+    # 3. コントローラー削除
+    - name: Destroy Controller Infrastructure
+      ansible.builtin.include_role:
+        name: jenkins_controller
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_controller | bool
+    
+    # 4. ロードバランサー削除
+    - name: Destroy LoadBalancer Infrastructure
+      ansible.builtin.include_role:
+        name: jenkins_loadbalancer
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_loadbalancer | bool
+    
+    # 5. ストレージ削除
+    - name: Destroy Storage Infrastructure
+      ansible.builtin.include_role:
+        name: jenkins_storage
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_storage | bool
+    
+    # 6. セキュリティグループ削除
+    - name: Destroy Security Groups
+      ansible.builtin.include_role:
+        name: jenkins_security
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_security | bool
+    
+    # 7. ネットワーク削除（最後に実行）
+    - name: Destroy Network Infrastructure
+      ansible.builtin.include_role:
+        name: jenkins_network
+      vars:
+        operation: "destroy"
+        remove_stacks: "{{ remove_stacks }}"
+      when: tear_network | bool
+    
+    # 削除結果のサマリー表示
+    - name: Display teardown results
+      ansible.builtin.debug:
+        msg: |
+          Jenkins Infrastructure Teardown Results
+          =====================================
+          Components destroyed:
+          - Config: {{ config_destroyed | default('Not selected') if tear_config else 'Not selected' }}
+          - Agent: {{ agent_destroyed | default('Not selected') if tear_agent else 'Not selected' }}
+          - Controller: {{ controller_destroyed | default('Not selected') if tear_controller else 'Not selected' }}
+          - LoadBalancer: {{ loadbalancer_destroyed | default('Not selected') if tear_loadbalancer else 'Not selected' }}
+          - Storage: {{ storage_destroyed | default('Not selected') if tear_storage else 'Not selected' }}
+          - Security: {{ security_destroyed | default('Not selected') if tear_security else 'Not selected' }}
+          - Network: {{ network_destroyed | default('Not selected') if tear_network else 'Not selected' }}
+          
+          Pulumi stacks removed: {{ remove_stacks }}
+          
+          {{ "All selected components have been destroyed successfully!" if
+             (not tear_config or (tear_config and config_destroyed | default(false))) and
+             (not tear_agent or (tear_agent and agent_destroyed | default(false))) and
+             (not tear_controller or (tear_controller and controller_destroyed | default(false))) and
+             (not tear_loadbalancer or (tear_loadbalancer and loadbalancer_destroyed | default(false))) and
+             (not tear_storage or (tear_storage and storage_destroyed | default(false))) and
+             (not tear_security or (tear_security and security_destroyed | default(false))) and
+             (not tear_network or (tear_network and network_destroyed | default(false)))
+             else "Some components failed to be destroyed. Check the logs above for details." }}

--- a/ansible/playbooks/jenkins_teardown_pipeline.yml
+++ b/ansible/playbooks/jenkins_teardown_pipeline.yml
@@ -40,17 +40,17 @@
       
     - name: Set remove_stacks flag
       ansible.builtin.set_fact:
-        remove_stacks: "{{ lookup('env', 'REMOVE_STACKS') | default(lookup('vars', 'remove_stacks_input') | default('false')) }}"
+        remove_stack_flag: "{{ remove_stacks | default('false') }}"
       
     - name: Set component teardown flags
       ansible.builtin.set_fact:
-        tear_config: "{{ lookup('env', 'TEAR_CONFIG') | default(lookup('vars', 'tear_config_input') | default('true')) }}"
-        tear_agent: "{{ lookup('env', 'TEAR_AGENT') | default(lookup('vars', 'tear_agent_input') | default('true')) }}"
-        tear_controller: "{{ lookup('env', 'TEAR_CONTROLLER') | default(lookup('vars', 'tear_controller_input') | default('true')) }}"
-        tear_loadbalancer: "{{ lookup('env', 'TEAR_LOADBALANCER') | default(lookup('vars', 'tear_loadbalancer_input') | default('true')) }}"
-        tear_storage: "{{ lookup('env', 'TEAR_STORAGE') | default(lookup('vars', 'tear_storage_input') | default('true')) }}"
-        tear_security: "{{ lookup('env', 'TEAR_SECURITY') | default(lookup('vars', 'tear_security_input') | default('true')) }}"
-        tear_network: "{{ lookup('env', 'TEAR_NETWORK') | default(lookup('vars', 'tear_network_input') | default('true')) }}"
+        tear_config_flag: "{{ tear_config | default('true') }}"
+        tear_agent_flag: "{{ tear_agent | default('true') }}"
+        tear_controller_flag: "{{ tear_controller | default('true') }}"
+        tear_loadbalancer_flag: "{{ tear_loadbalancer | default('true') }}"
+        tear_storage_flag: "{{ tear_storage | default('true') }}"
+        tear_security_flag: "{{ tear_security | default('true') }}"
+        tear_network_flag: "{{ tear_network | default('true') }}"
       
   roles:
     - aws_setup
@@ -93,6 +93,17 @@
           Environment: {{ env_name }}
           AWS Region: {{ aws_region_name }}
           
+          Components to destroy:
+          - Config: {{ tear_config_flag }}
+          - Agent: {{ tear_agent_flag }}
+          - Controller: {{ tear_controller_flag }}
+          - LoadBalancer: {{ tear_loadbalancer_flag }}
+          - Storage: {{ tear_storage_flag }}
+          - Security: {{ tear_security_flag }}
+          - Network: {{ tear_network_flag }}
+          
+          Remove Pulumi stacks: {{ remove_stack_flag }}
+          
           WARNING: This will destroy your Jenkins infrastructure!
           Use --extra-vars "confirm=true" to proceed.
     
@@ -114,7 +125,8 @@
         name: jenkins_config
       vars:
         operation: "destroy"
-      when: tear_config == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_config_flag == 'true'
     
     # 1. エージェント削除
     - name: Destroy Agent Infrastructure
@@ -122,7 +134,8 @@
         name: jenkins_agent
       vars:
         operation: "destroy"
-      when: tear_agent == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_agent_flag == 'true'
     
     # 2. コントローラー削除
     - name: Destroy Controller Infrastructure
@@ -130,7 +143,8 @@
         name: jenkins_controller
       vars:
         operation: "destroy"
-      when: tear_controller == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_controller_flag == 'true'
     
     # 3. ロードバランサー削除
     - name: Destroy LoadBalancer Infrastructure
@@ -138,7 +152,8 @@
         name: jenkins_loadbalancer
       vars:
         operation: "destroy"
-      when: tear_loadbalancer == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_loadbalancer_flag == 'true'
     
     # 4. ストレージ削除
     - name: Destroy Storage Infrastructure
@@ -146,7 +161,8 @@
         name: jenkins_storage
       vars:
         operation: "destroy"
-      when: tear_storage == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_storage_flag == 'true'
     
     # 5. セキュリティグループ削除
     - name: Destroy Security Groups
@@ -154,7 +170,8 @@
         name: jenkins_security
       vars:
         operation: "destroy"
-      when: tear_security == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_security_flag == 'true'
     
     # 6. ネットワーク削除（最後に実行）
     - name: Destroy Network Infrastructure
@@ -162,7 +179,8 @@
         name: jenkins_network
       vars:
         operation: "destroy"
-      when: tear_network == 'true'
+        remove_stacks: "{{ remove_stack_flag }}"
+      when: tear_network_flag == 'true'
     
     # 削除結果のサマリー表示
     - name: Display teardown results

--- a/ansible/playbooks/jenkins_teardown_pipeline.yml
+++ b/ansible/playbooks/jenkins_teardown_pipeline.yml
@@ -36,21 +36,27 @@
     # 各フラグは別々のステップで設定する
     - name: Set confirm_destroy flag
       ansible.builtin.set_fact:
-        confirm_destroy: "{{ confirm | default('false') }}"
+        confirm_destroy: "{{ confirm | default(false) }}"
+
+    # デバッグ出力を追加して変数の値を確認
+    - name: Debug confirm variable
+      ansible.builtin.debug:
+        msg: "confirm variable is: {{ confirm | default('not set') }}, confirm_destroy is: {{ confirm_destroy }}"
+      when: ansible_verbosity > 0
       
     - name: Set remove_stacks flag
       ansible.builtin.set_fact:
-        remove_stack_flag: "{{ remove_stacks | default('false') }}"
+        remove_stack_flag: "{{ remove_stacks | default(false) }}"
       
     - name: Set component teardown flags
       ansible.builtin.set_fact:
-        tear_config_flag: "{{ tear_config | default('true') }}"
-        tear_agent_flag: "{{ tear_agent | default('true') }}"
-        tear_controller_flag: "{{ tear_controller | default('true') }}"
-        tear_loadbalancer_flag: "{{ tear_loadbalancer | default('true') }}"
-        tear_storage_flag: "{{ tear_storage | default('true') }}"
-        tear_security_flag: "{{ tear_security | default('true') }}"
-        tear_network_flag: "{{ tear_network | default('true') }}"
+        tear_config_flag: "{{ tear_config | default(true) }}"
+        tear_agent_flag: "{{ tear_agent | default(true) }}"
+        tear_controller_flag: "{{ tear_controller | default(true) }}"
+        tear_loadbalancer_flag: "{{ tear_loadbalancer | default(true) }}"
+        tear_storage_flag: "{{ tear_storage | default(true) }}"
+        tear_security_flag: "{{ tear_security | default(true) }}"
+        tear_network_flag: "{{ tear_network | default(true) }}"
       
   roles:
     - aws_setup
@@ -111,13 +117,13 @@
     - name: Verify teardown confirmation
       ansible.builtin.fail:
         msg: "Teardown not confirmed. Please run with --extra-vars 'confirm=true' to proceed."
-      when: confirm_destroy != 'true'
+      when: not confirm_destroy | bool
     
     # 確認後にプロセスを継続
     - name: Confirm teardown process
       ansible.builtin.debug:
         msg: "Teardown confirmed. Proceeding with infrastructure destruction..."
-      when: confirm_destroy == 'true'
+      when: confirm_destroy | bool
     
     # 0. Config削除（SSMドキュメント）
     - name: Destroy Jenkins Configuration Resources
@@ -126,7 +132,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_config_flag == 'true'
+      when: tear_config_flag | bool
     
     # 1. エージェント削除
     - name: Destroy Agent Infrastructure
@@ -135,7 +141,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_agent_flag == 'true'
+      when: tear_agent_flag | bool
     
     # 2. コントローラー削除
     - name: Destroy Controller Infrastructure
@@ -144,7 +150,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_controller_flag == 'true'
+      when: tear_controller_flag | bool
     
     # 3. ロードバランサー削除
     - name: Destroy LoadBalancer Infrastructure
@@ -153,7 +159,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_loadbalancer_flag == 'true'
+      when: tear_loadbalancer_flag | bool
     
     # 4. ストレージ削除
     - name: Destroy Storage Infrastructure
@@ -162,7 +168,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_storage_flag == 'true'
+      when: tear_storage_flag | bool
     
     # 5. セキュリティグループ削除
     - name: Destroy Security Groups
@@ -171,7 +177,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_security_flag == 'true'
+      when: tear_security_flag | bool
     
     # 6. ネットワーク削除（最後に実行）
     - name: Destroy Network Infrastructure
@@ -180,7 +186,7 @@
       vars:
         operation: "destroy"
         remove_stacks: "{{ remove_stack_flag }}"
-      when: tear_network_flag == 'true'
+      when: tear_network_flag | bool
     
     # 削除結果のサマリー表示
     - name: Display teardown results

--- a/ansible/playbooks/jenkins_teardown_pipeline.yml
+++ b/ansible/playbooks/jenkins_teardown_pipeline.yml
@@ -13,10 +13,6 @@
     # パスを明示的に定義
     scripts_dir: "{{ playbook_dir }}/../../scripts"
     pulumi_path: "{{ playbook_dir }}/../../pulumi"
-    # 削除確認フラグ（デフォルトはfalse）
-    confirm_destroy: "{{ confirm | default(false) | bool }}"
-    # スタック削除フラグ（デフォルトはfalse）
-    remove_stacks: "{{ remove_stacks | default(false) | bool }}"
   
   pre_tasks:
     # all.yml から変数を読み込む
@@ -37,17 +33,25 @@
         agent_project_name: "{{ infra.pulumi.agent_project }}"
         config_project_name: "{{ infra.pulumi.config_project }}"
     
-    # コンポーネント削除フラグの設定（デフォルトは全てtrue）
+    # 各フラグは別々のステップで設定する
+    - name: Set confirm_destroy flag
+      ansible.builtin.set_fact:
+        confirm_destroy: "{{ confirm | default('false') }}"
+      
+    - name: Set remove_stacks flag
+      ansible.builtin.set_fact:
+        remove_stacks: "{{ lookup('env', 'REMOVE_STACKS') | default(lookup('vars', 'remove_stacks_input') | default('false')) }}"
+      
     - name: Set component teardown flags
       ansible.builtin.set_fact:
-        tear_config: "{{ tear_config | default(true) | bool }}"
-        tear_agent: "{{ tear_agent | default(true) | bool }}"
-        tear_controller: "{{ tear_controller | default(true) | bool }}"
-        tear_loadbalancer: "{{ tear_loadbalancer | default(true) | bool }}"
-        tear_storage: "{{ tear_storage | default(true) | bool }}"
-        tear_security: "{{ tear_security | default(true) | bool }}"
-        tear_network: "{{ tear_network | default(true) | bool }}"
-
+        tear_config: "{{ lookup('env', 'TEAR_CONFIG') | default(lookup('vars', 'tear_config_input') | default('true')) }}"
+        tear_agent: "{{ lookup('env', 'TEAR_AGENT') | default(lookup('vars', 'tear_agent_input') | default('true')) }}"
+        tear_controller: "{{ lookup('env', 'TEAR_CONTROLLER') | default(lookup('vars', 'tear_controller_input') | default('true')) }}"
+        tear_loadbalancer: "{{ lookup('env', 'TEAR_LOADBALANCER') | default(lookup('vars', 'tear_loadbalancer_input') | default('true')) }}"
+        tear_storage: "{{ lookup('env', 'TEAR_STORAGE') | default(lookup('vars', 'tear_storage_input') | default('true')) }}"
+        tear_security: "{{ lookup('env', 'TEAR_SECURITY') | default(lookup('vars', 'tear_security_input') | default('true')) }}"
+        tear_network: "{{ lookup('env', 'TEAR_NETWORK') | default(lookup('vars', 'tear_network_input') | default('true')) }}"
+      
   roles:
     - aws_setup
     - pulumi_helper
@@ -89,17 +93,6 @@
           Environment: {{ env_name }}
           AWS Region: {{ aws_region_name }}
           
-          Components to destroy:
-          - Config: {{ tear_config }}
-          - Agent: {{ tear_agent }}
-          - Controller: {{ tear_controller }}
-          - LoadBalancer: {{ tear_loadbalancer }}
-          - Storage: {{ tear_storage }}
-          - Security: {{ tear_security }}
-          - Network: {{ tear_network }}
-          
-          Remove Pulumi stacks: {{ remove_stacks }}
-          
           WARNING: This will destroy your Jenkins infrastructure!
           Use --extra-vars "confirm=true" to proceed.
     
@@ -107,13 +100,21 @@
     - name: Verify teardown confirmation
       ansible.builtin.fail:
         msg: "Teardown not confirmed. Please run with --extra-vars 'confirm=true' to proceed."
-      when: not confirm_destroy | bool
+      when: confirm_destroy != 'true'
     
     # 確認後にプロセスを継続
     - name: Confirm teardown process
       ansible.builtin.debug:
         msg: "Teardown confirmed. Proceeding with infrastructure destruction..."
-      when: confirm_destroy | bool
+      when: confirm_destroy == 'true'
+    
+    # 0. Config削除（SSMドキュメント）
+    - name: Destroy Jenkins Configuration Resources
+      ansible.builtin.include_role:
+        name: jenkins_config
+      vars:
+        operation: "destroy"
+      when: tear_config == 'true'
     
     # 1. エージェント削除
     - name: Destroy Agent Infrastructure
@@ -121,63 +122,47 @@
         name: jenkins_agent
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_agent | bool
+      when: tear_agent == 'true'
     
-
-    # 2. Config削除（SSMドキュメント）
-    - name: Destroy Jenkins Configuration Resources
-      ansible.builtin.include_role:
-        name: jenkins_config
-      vars:
-        operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_config | bool
-    
-    # 3. コントローラー削除
+    # 2. コントローラー削除
     - name: Destroy Controller Infrastructure
       ansible.builtin.include_role:
         name: jenkins_controller
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_controller | bool
+      when: tear_controller == 'true'
     
-    # 4. ロードバランサー削除
+    # 3. ロードバランサー削除
     - name: Destroy LoadBalancer Infrastructure
       ansible.builtin.include_role:
         name: jenkins_loadbalancer
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_loadbalancer | bool
+      when: tear_loadbalancer == 'true'
     
-    # 5. ストレージ削除
+    # 4. ストレージ削除
     - name: Destroy Storage Infrastructure
       ansible.builtin.include_role:
         name: jenkins_storage
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_storage | bool
+      when: tear_storage == 'true'
     
-    # 6. セキュリティグループ削除
+    # 5. セキュリティグループ削除
     - name: Destroy Security Groups
       ansible.builtin.include_role:
         name: jenkins_security
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_security | bool
+      when: tear_security == 'true'
     
-    # 7. ネットワーク削除（最後に実行）
+    # 6. ネットワーク削除（最後に実行）
     - name: Destroy Network Infrastructure
       ansible.builtin.include_role:
         name: jenkins_network
       vars:
         operation: "destroy"
-        remove_stacks: "{{ remove_stacks }}"
-      when: tear_network | bool
+      when: tear_network == 'true'
     
     # 削除結果のサマリー表示
     - name: Display teardown results
@@ -185,23 +170,5 @@
         msg: |
           Jenkins Infrastructure Teardown Results
           =====================================
-          Components destroyed:
-          - Config: {{ config_destroyed | default('Not selected') if tear_config else 'Not selected' }}
-          - Agent: {{ agent_destroyed | default('Not selected') if tear_agent else 'Not selected' }}
-          - Controller: {{ controller_destroyed | default('Not selected') if tear_controller else 'Not selected' }}
-          - LoadBalancer: {{ loadbalancer_destroyed | default('Not selected') if tear_loadbalancer else 'Not selected' }}
-          - Storage: {{ storage_destroyed | default('Not selected') if tear_storage else 'Not selected' }}
-          - Security: {{ security_destroyed | default('Not selected') if tear_security else 'Not selected' }}
-          - Network: {{ network_destroyed | default('Not selected') if tear_network else 'Not selected' }}
-          
-          Pulumi stacks removed: {{ remove_stacks }}
-          
-          {{ "All selected components have been destroyed successfully!" if
-             (not tear_config or (tear_config and config_destroyed | default(false))) and
-             (not tear_agent or (tear_agent and agent_destroyed | default(false))) and
-             (not tear_controller or (tear_controller and controller_destroyed | default(false))) and
-             (not tear_loadbalancer or (tear_loadbalancer and loadbalancer_destroyed | default(false))) and
-             (not tear_storage or (tear_storage and storage_destroyed | default(false))) and
-             (not tear_security or (tear_security and security_destroyed | default(false))) and
-             (not tear_network or (tear_network and network_destroyed | default(false)))
-             else "Some components failed to be destroyed. Check the logs above for details." }}
+          Teardown process completed.
+          Check the logs above for details of each component's status.

--- a/ansible/roles/jenkins_agent/tasks/destroy.yml
+++ b/ansible/roles/jenkins_agent/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# エージェント削除タスク
+
+- name: Display agent destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Agent Infrastructure:
+      - Project: {{ project_name }}
+      - Agent Pulumi Project: {{ agent_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Agent Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize agent stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy agent resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove agent stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-agent"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set agent destruction status on success
+      ansible.builtin.set_fact:
+        agent_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set agent destruction status on failure
+      ansible.builtin.set_fact:
+        agent_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy agent infrastructure. See error details above."

--- a/ansible/roles/jenkins_agent/tasks/main.yml
+++ b/ansible/roles/jenkins_agent/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_config/tasks/destroy.yml
+++ b/ansible/roles/jenkins_config/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# Jenkins設定リソース削除タスク
+
+- name: Display config destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Configuration Resources:
+      - Project: {{ project_name }}
+      - Config Pulumi Project: {{ config_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Configuration Resources with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize config stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-config"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy config resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-config"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove config stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-config"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set config destruction status on success
+      ansible.builtin.set_fact:
+        config_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set config destruction status on failure
+      ansible.builtin.set_fact:
+        config_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy config resources. See error details above."

--- a/ansible/roles/jenkins_config/tasks/main.yml
+++ b/ansible/roles/jenkins_config/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include setup tasks
   ansible.builtin.include_tasks: setup.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_controller/tasks/destroy.yml
+++ b/ansible/roles/jenkins_controller/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# コントローラー削除タスク
+
+- name: Display controller destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Controller Infrastructure:
+      - Project: {{ project_name }}
+      - Controller Pulumi Project: {{ controller_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Controller Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize controller stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy controller resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove controller stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-controller"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set controller destruction status on success
+      ansible.builtin.set_fact:
+        controller_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set controller destruction status on failure
+      ansible.builtin.set_fact:
+        controller_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy controller infrastructure. See error details above."

--- a/ansible/roles/jenkins_controller/tasks/main.yml
+++ b/ansible/roles/jenkins_controller/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_loadbalancer/tasks/destroy.yml
+++ b/ansible/roles/jenkins_loadbalancer/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# ロードバランサー削除タスク
+
+- name: Display loadbalancer destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins LoadBalancer Infrastructure:
+      - Project: {{ project_name }}
+      - LoadBalancer Pulumi Project: {{ loadbalancer_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy LoadBalancer Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize loadbalancer stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-loadbalancer"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy loadbalancer resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-loadbalancer"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove loadbalancer stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-loadbalancer"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set loadbalancer destruction status on success
+      ansible.builtin.set_fact:
+        loadbalancer_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set loadbalancer destruction status on failure
+      ansible.builtin.set_fact:
+        loadbalancer_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy loadbalancer infrastructure. See error details above."

--- a/ansible/roles/jenkins_loadbalancer/tasks/main.yml
+++ b/ansible/roles/jenkins_loadbalancer/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_network/tasks/destroy.yml
+++ b/ansible/roles/jenkins_network/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# ネットワーク削除タスク
+
+- name: Display network destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Network Infrastructure:
+      - Project: {{ project_name }}
+      - Network Pulumi Project: {{ network_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Network Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize network stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-network"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy network resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-network"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove network stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-network"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set network destruction status on success
+      ansible.builtin.set_fact:
+        network_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set network destruction status on failure
+      ansible.builtin.set_fact:
+        network_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy network infrastructure. See error details above."

--- a/ansible/roles/jenkins_network/tasks/main.yml
+++ b/ansible/roles/jenkins_network/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_security/tasks/destroy.yml
+++ b/ansible/roles/jenkins_security/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# セキュリティグループ削除タスク
+
+- name: Display security destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Security Infrastructure:
+      - Project: {{ project_name }}
+      - Security Pulumi Project: {{ security_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Security Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize security stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-security"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy security resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-security"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove security stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-security"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set security destruction status on success
+      ansible.builtin.set_fact:
+        security_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set security destruction status on failure
+      ansible.builtin.set_fact:
+        security_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy security infrastructure. See error details above."

--- a/ansible/roles/jenkins_security/tasks/main.yml
+++ b/ansible/roles/jenkins_security/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/jenkins_storage/tasks/destroy.yml
+++ b/ansible/roles/jenkins_storage/tasks/destroy.yml
@@ -1,0 +1,64 @@
+---
+# ストレージ（EFS）削除タスク
+
+- name: Display storage destruction information
+  ansible.builtin.debug:
+    msg: |
+      Destroying Jenkins Storage Infrastructure:
+      - Project: {{ project_name }}
+      - Storage Pulumi Project: {{ storage_project_name }}
+      - Environment: {{ env_name }}
+      - Remove Stack: {{ remove_stacks | default(false) }}
+
+# ファイル権限設定
+- name: Ensure aws-env.sh has execute permissions
+  ansible.builtin.file:
+    path: "{{ scripts_dir }}/aws-env.sh"
+    mode: '0755'
+  register: aws_env_script_permission
+  no_log: true  # 詳細なログを抑制
+
+# Pulumiによる削除
+- name: Destroy Storage Infrastructure with Pulumi
+  block:
+    # Pulumiヘルパータスクを呼び出す
+    - name: Initialize storage stack
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: init_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-storage"
+        stack_name: "{{ env_name }}"
+    
+    # Pulumiリソースの削除
+    - name: Destroy storage resources with Pulumi
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: destroy
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-storage"
+    
+    # スタック自体の削除（オプション）
+    - name: Remove storage stack (if requested)
+      ansible.builtin.include_role:
+        name: pulumi_helper
+        tasks_from: remove_stack
+      vars:
+        pulumi_project_path: "{{ pulumi_path }}/jenkins-storage"
+        stack_name: "{{ env_name }}"
+      when: remove_stacks | default(false) | bool
+    
+    # 削除ステータスの設定
+    - name: Set storage destruction status on success
+      ansible.builtin.set_fact:
+        storage_destroyed: true
+  
+  rescue:
+    # エラーハンドリング
+    - name: Set storage destruction status on failure
+      ansible.builtin.set_fact:
+        storage_destroyed: false
+    
+    - name: Display error
+      ansible.builtin.debug:
+        msg: "Failed to destroy storage infrastructure. See error details above."

--- a/ansible/roles/jenkins_storage/tasks/main.yml
+++ b/ansible/roles/jenkins_storage/tasks/main.yml
@@ -3,3 +3,8 @@
 
 - name: Include deploy tasks
   ansible.builtin.include_tasks: deploy.yml
+  when: operation | default('deploy') == 'deploy'
+
+- name: Include destroy tasks
+  ansible.builtin.include_tasks: destroy.yml
+  when: operation | default('deploy') == 'destroy'

--- a/ansible/roles/pulumi_helper/tasks/destroy.yml
+++ b/ansible/roles/pulumi_helper/tasks/destroy.yml
@@ -9,12 +9,34 @@
       register: pulumi_destroy_result
       changed_when: "'No resources to destroy' not in pulumi_destroy_result.stdout"
       when: not ansible_check_mode
+      async: 600  # 10分のタイムアウト
+      poll: 10    # 10秒ごとにポーリング
   
     - name: Display Pulumi destroy results
       ansible.builtin.debug:
         msg: "{{ pulumi_destroy_result.stdout_lines }}"
       when: not ansible_check_mode and ansible_verbosity > 0
   rescue:
+    - name: Check if conflict error occurred
+      when: "'Another update is currently in progress' in pulumi_destroy_result.stderr | default('')"
+      block:
+        - name: Cancel current operation
+          ansible.builtin.shell: |
+            cd {{ pulumi_project_path }}
+            export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+            sudo -E {{ pulumi_bin_path }} cancel
+          ignore_errors: true
+        
+        - name: Wait before retry
+          ansible.builtin.pause:
+            seconds: 30
+        
+        - name: Retry destroy operation
+          ansible.builtin.shell: |
+            cd {{ pulumi_project_path }}
+            {{ pulumi_commands.destroy }}
+          register: pulumi_destroy_retry_result
+    
     - name: Display error message on destruction failure
       ansible.builtin.debug:
         msg: "Failed to destroy Pulumi stack. Check error message above."

--- a/ansible/roles/pulumi_helper/tasks/main.yml
+++ b/ansible/roles/pulumi_helper/tasks/main.yml
@@ -65,7 +65,9 @@
 
 # Pulumiのログイン状態確認
 - name: Check Pulumi login status
-  ansible.builtin.command: sudo {{ pulumi_bin_path }} whoami
+  ansible.builtin.shell: |
+    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+    sudo -E {{ pulumi_bin_path }} whoami
   register: pulumi_login_check
   changed_when: false
   failed_when: false
@@ -81,9 +83,9 @@
     pulumi_token_set: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') | length > 0 }}"
 
 - name: Login to Pulumi using access token from environment
-  ansible.builtin.command: sudo {{ pulumi_bin_path }} login
-  environment:
-    PULUMI_ACCESS_TOKEN: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+  ansible.builtin.shell: |
+    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+    sudo -E {{ pulumi_bin_path }} login
   when: 
     - pulumi_token_set 
     - pulumi_login_check.rc != 0
@@ -102,7 +104,9 @@
     - pulumi_login_check.rc != 0
 
 - name: Verify Pulumi login after attempts
-  ansible.builtin.command: sudo {{ pulumi_bin_path }} whoami
+  ansible.builtin.shell: |
+    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+    sudo -E {{ pulumi_bin_path }} whoami
   register: pulumi_verify_login
   failed_when: 
     - pulumi_token_set 
@@ -115,18 +119,18 @@
     msg: "Pulumi login verified: {{ pulumi_verify_login.stdout if pulumi_verify_login.rc == 0 else 'Failed to verify login' }}"
   when: pulumi_token_set
 
-# Pulumiコマンド定義
+# Pulumiコマンド定義（PULUMI_ACCESS_TOKENを含むように修正）
 - name: Set Pulumi standard tasks
   ansible.builtin.set_fact:
     pulumi_commands:
-      preview: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} preview"
-      up: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} up --yes"
-      destroy: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} destroy --yes"
-      refresh: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} refresh --yes"
-      stack_output: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack output"
-      stack_ls: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack ls"
-      stack_rm: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack rm --yes"
-      config_set: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} config set"
+      preview: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} preview"
+      up: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} up --yes"
+      destroy: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} destroy --yes"
+      refresh: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} refresh --yes"
+      stack_output: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack output"
+      stack_ls: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack ls"
+      stack_rm: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack rm --yes"
+      config_set: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} config set"
       build: "npm run build"
       tsc: "npx tsc"
 

--- a/ansible/roles/pulumi_helper/tasks/main.yml
+++ b/ansible/roles/pulumi_helper/tasks/main.yml
@@ -125,6 +125,7 @@
       refresh: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} refresh --yes"
       stack_output: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack output"
       stack_ls: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack ls"
+      stack_rm: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack rm --yes"
       config_set: "source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} config set"
       build: "npm run build"
       tsc: "npx tsc"
@@ -140,3 +141,5 @@
     pulumi_config_failed: false
     stack_output_succeeded: false
     stack_output_failed: false
+    stack_rm_failed: false
+    stack_init_failed: false

--- a/ansible/roles/pulumi_helper/tasks/remove_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/remove_stack.yml
@@ -1,0 +1,63 @@
+# Pulumiスタックを削除するヘルパータスク
+
+- name: Remove Pulumi stack
+  block:
+    # スタック名が指定されているか確認
+    - name: Verify stack name is provided
+      ansible.builtin.fail:
+        msg: "Required variable 'stack_name' is not defined"
+      when: stack_name is not defined or stack_name | length == 0
+    
+    # スタックの存在を確認
+    - name: Check if stack exists
+      ansible.builtin.shell: |
+        cd {{ pulumi_project_path }}
+        source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
+        eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
+        sudo -E {{ pulumi_bin_path }} stack ls | grep {{ stack_name }} || echo "stack_not_found"
+      register: stack_check_result
+      changed_when: false
+      failed_when: false
+      when: not ansible_check_mode
+    
+    # スタックが存在しない場合は警告を表示して終了
+    - name: Skip if stack does not exist
+      ansible.builtin.debug:
+        msg: "Stack '{{ stack_name }}' does not exist in project {{ pulumi_project_path }}. Skipping removal."
+      when: 
+        - not ansible_check_mode
+        - stack_check_result is defined 
+        - "'stack_not_found' in stack_check_result.stdout"
+    
+    # スタックの削除（rm）を実行
+    - name: Remove stack with Pulumi
+      ansible.builtin.shell: |
+        cd {{ pulumi_project_path }}
+        source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
+        eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
+        sudo -E {{ pulumi_bin_path }} stack rm --yes {{ stack_name }}
+      register: stack_rm_result
+      changed_when: stack_rm_result.rc == 0
+      failed_when: false
+      when: 
+        - not ansible_check_mode
+        - stack_check_result is defined
+        - "'stack_not_found' not in stack_check_result.stdout"
+    
+    # スタック削除の結果を表示
+    - name: Display stack removal result
+      ansible.builtin.debug:
+        msg: "Successfully removed stack '{{ stack_name }}' from project {{ pulumi_project_path }}"
+      when: 
+        - not ansible_check_mode
+        - stack_rm_result is defined
+        - stack_rm_result.rc == 0
+  rescue:
+    - name: Display error message on stack removal failure
+      ansible.builtin.debug:
+        msg: "Failed to remove Pulumi stack '{{ stack_name }}'. Check error message above."
+
+- name: Mock stack removal (check mode)
+  ansible.builtin.debug:
+    msg: "Would remove Pulumi stack '{{ stack_name }}' from project {{ pulumi_project_path }} (check mode active)"
+  when: ansible_check_mode

--- a/ansible/roles/pulumi_helper/tasks/remove_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/remove_stack.yml
@@ -51,7 +51,19 @@
       when: 
         - not ansible_check_mode
         - stack_rm_result is defined
+        - stack_rm_result.rc is defined
         - stack_rm_result.rc == 0
+
+    # スタック削除に失敗した場合のメッセージ
+    - name: Display stack removal failure
+      ansible.builtin.debug:
+        msg: "Failed to remove stack '{{ stack_name }}'. Return code: {{ stack_rm_result.rc | default('N/A') }}"
+      when:
+        - not ansible_check_mode
+        - stack_rm_result is defined
+        - stack_rm_result.rc is defined
+        - stack_rm_result.rc != 0
+  
   rescue:
     - name: Display error message on stack removal failure
       ansible.builtin.debug:


### PR DESCRIPTION
# PR概要
このPRは、Jenkins インフラストラクチャの削除（teardown）機能を追加し、Pulumi の認証エラーを修正するものです。

## 主な変更内容

### 1. Jenkins インフラ削除パイプラインの追加
- `jenkins_teardown_pipeline.yml` プレイブックを新規作成
- 全コンポーネントを安全に逆順で削除する機能を実装
- 削除前の確認機構（`confirm=true`）を追加

### 2. 各 Jenkins ロールへの削除タスク追加
以下の各ロールに `destroy.yml` タスクを追加：
- `jenkins_config`
- `jenkins_agent`
- `jenkins_controller`
- `jenkins_loadbalancer`
- `jenkins_storage`
- `jenkins_security`
- `jenkins_network`

### 3. Pulumi ヘルパーロールの機能強化
- **認証エラーの修正**: `PULUMI_ACCESS_TOKEN` 環境変数を適切に `sudo` 環境に渡すように修正
- `remove_stack.yml` タスクを追加（Pulumi スタック自体の削除機能）
- `destroy.yml` にコンフリクトエラー時の自動リトライ機能を追加

### 4. EFS ストレージの削除順序の最適化
- マウントターゲットの依存関係を明示的に設定
- 削除時のエラーを防ぐため、リソースの削除順序を最適化

## 使用方法

### インフラの削除
```bash
# 削除の確認（ドライラン）
ansible-playbook ansible/playbooks/jenkins_teardown_pipeline.yml -e "env=dev"

# 実際に削除を実行
ansible-playbook ansible/playbooks/jenkins_teardown_pipeline.yml -e "env=dev confirm=true"

# 特定のコンポーネントのみ削除
ansible-playbook ansible/playbooks/jenkins_teardown_pipeline.yml \
  -e "env=dev confirm=true tear_network=false tear_security=false"

# Pulumi スタックも含めて完全に削除
ansible-playbook ansible/playbooks/jenkins_teardown_pipeline.yml \
  -e "env=dev confirm=true remove_stacks=true"

# 別環境（prod）の削除
ansible-playbook ansible/playbooks/jenkins_teardown_pipeline.yml \
  -e "env=prod confirm=true remove_stacks=true"
```

## 必須パラメータ
- `env`: 削除対象の環境名（dev, staging, prod など）
- `confirm`: 削除実行の確認フラグ（true を指定しない限り削除は実行されません）

## オプションパラメータ
- `remove_stacks`: Pulumi スタック自体も削除する場合は true を指定（デフォルト: false）
- `tear_config`: Config リソースを削除（デフォルト: true）
- `tear_agent`: Agent リソースを削除（デフォルト: true）
- `tear_controller`: Controller リソースを削除（デフォルト: true）
- `tear_loadbalancer`: LoadBalancer リソースを削除（デフォルト: true）
- `tear_storage`: Storage リソースを削除（デフォルト: true）
- `tear_security`: Security リソースを削除（デフォルト: true）
- `tear_network`: Network リソースを削除（デフォルト: true）

## 技術的な詳細

### Pulumi 認証エラーの修正
`aws-env.sh` に `PULUMI_ACCESS_TOKEN` が含まれていない環境で、`sudo` コマンド実行時に環境変数が失われる問題を修正：

```yaml
# 修正前
- name: Login to Pulumi
  ansible.builtin.command: sudo {{ pulumi_bin_path }} login

# 修正後
- name: Login to Pulumi
  ansible.builtin.shell: |
    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
    sudo -E {{ pulumi_bin_path }} login
```

### 削除順序の制御
インフラストラクチャの依存関係を考慮し、以下の順序で削除を実行：
1. Config (SSMドキュメント)
2. Agent (EC2インスタンス)
3. Controller (EC2インスタンス)
4. LoadBalancer (ALB)
5. Storage (EFS)
6. Security (セキュリティグループ)
7. Network (VPC、サブネット)

## 環境変数の設定
実行前に以下の環境変数を設定する必要があります：
```bash
export PULUMI_ACCESS_TOKEN="pul-YOUR_ACCESS_TOKEN"
```

## 注意事項
- 削除操作は破壊的な操作のため、必ず `confirm=true` の指定が必要です
- 環境名 (`env`) の指定を忘れずに行ってください
- 削除前に重要なデータのバックアップを取ることを推奨します
- EFS に保存されている Jenkins データは削除されます
- 誤った環境を削除しないよう、`env` パラメータを十分に確認してください