### PR TITLE
Pulumi認証処理をlogin.ymlに集約し共通include化

### DIFF
--- a/ansible/roles/pulumi_helper/tasks/check_stack_exists.yml
+++ b/ansible/roles/pulumi_helper/tasks/check_stack_exists.yml
@@ -2,11 +2,15 @@
 # 入力: resolved_stack_name
 # 出力: stack_exists (true/false)
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: List all available stacks
   ansible.builtin.shell: |
     cd {{ pulumi_project_path }}
-    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-    sudo -E {{ pulumi_bin_path }} stack ls --json 2>/dev/null || echo '[]'
+    {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack ls --json 2>/dev/null || echo '[]'
   register: stack_list
   changed_when: false
   when: not ansible_check_mode

--- a/ansible/roles/pulumi_helper/tasks/deploy.yml
+++ b/ansible/roles/pulumi_helper/tasks/deploy.yml
@@ -1,13 +1,17 @@
 # Pulumiのデプロイ実行ヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Deploy with Pulumi
   block:
     # スタックが選択されているか確認
     - name: Ensure stack is selected
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name || exit 1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name || exit 1
       register: current_stack
       changed_when: false
       failed_when: current_stack.rc != 0

--- a/ansible/roles/pulumi_helper/tasks/destroy.yml
+++ b/ansible/roles/pulumi_helper/tasks/destroy.yml
@@ -1,13 +1,17 @@
 # Pulumiスタックを削除するヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Destroy Pulumi stack
   block:
     # スタックが選択されているか確認
     - name: Ensure stack is selected
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name || exit 1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name || exit 1
       register: current_stack
       changed_when: false
       failed_when: current_stack.rc != 0
@@ -38,8 +42,7 @@
         - name: Cancel current operation
           ansible.builtin.shell: |
             cd {{ pulumi_project_path }}
-            export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-            sudo -E {{ pulumi_bin_path }} cancel
+            {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} cancel
           ignore_errors: true
         
         - name: Wait before retry

--- a/ansible/roles/pulumi_helper/tasks/get_outputs.yml
+++ b/ansible/roles/pulumi_helper/tasks/get_outputs.yml
@@ -1,5 +1,10 @@
 # Pulumiスタックの出力を取得するヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Get stack outputs
   block:
     # 開始ログ
@@ -16,8 +21,7 @@
     - name: Check current stack selection
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name 2>/dev/null || echo "NO_STACK_SELECTED"
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name 2>/dev/null || echo "NO_STACK_SELECTED"
       register: current_stack_check
       changed_when: false
       when: not ansible_check_mode
@@ -45,17 +49,17 @@
             - name: Select specified stack
               ansible.builtin.shell: |
                 cd {{ pulumi_project_path }}
-                export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+                {{ pulumi_env_prefix }}
                 
                 # まず単純な名前で試す
-                if sudo -E {{ pulumi_bin_path }} stack select {{ stack_name }} 2>/dev/null; then
+                if {{ pulumi_sudo_cmd }} stack select {{ stack_name }} 2>/dev/null; then
                   echo "SELECTED: {{ stack_name }}"
                 else
                   # 失敗したら、スタック名を含むものを検索
                   echo "Simple name failed, searching for matching stacks..."
-                  MATCHING_STACK=$(sudo -E {{ pulumi_bin_path }} stack ls --json | jq -r '.[].name | select(endswith("/{{ stack_name }}"))' | head -1)
+                  MATCHING_STACK=$({{ pulumi_sudo_cmd }} stack ls --json | jq -r '.[].name | select(endswith("/{{ stack_name }}"))' | head -1)
                   if [ -n "$MATCHING_STACK" ]; then
-                    sudo -E {{ pulumi_bin_path }} stack select "$MATCHING_STACK"
+                    {{ pulumi_sudo_cmd }} stack select "$MATCHING_STACK"
                     echo "SELECTED: $MATCHING_STACK"
                   else
                     echo "ERROR: Stack {{ stack_name }} not found"
@@ -85,8 +89,7 @@
             - name: List all available stacks
               ansible.builtin.shell: |
                 cd {{ pulumi_project_path }}
-                export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-                sudo -E {{ pulumi_bin_path }} stack ls --json 2>/dev/null || echo '[]'
+                {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack ls --json 2>/dev/null || echo '[]'
               register: available_stacks_list
             
             - name: Display available stacks
@@ -98,11 +101,11 @@
             - name: Select first available stack
               ansible.builtin.shell: |
                 cd {{ pulumi_project_path }}
-                export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+                {{ pulumi_env_prefix }}
                 
                 FIRST_STACK=$(echo '{{ available_stacks_list.stdout }}' | jq -r '.[0].name // empty')
                 if [ -n "$FIRST_STACK" ]; then
-                  sudo -E {{ pulumi_bin_path }} stack select "$FIRST_STACK"
+                  {{ pulumi_sudo_cmd }} stack select "$FIRST_STACK"
                   echo "SELECTED: $FIRST_STACK"
                 else
                   echo "ERROR: No stacks available"
@@ -118,8 +121,7 @@
     - name: Verify final stack selection
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name
       register: final_stack_check
       changed_when: false
       when: not ansible_check_mode
@@ -135,14 +137,14 @@
     - name: Get stack output
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+        {{ pulumi_env_prefix }}
         
         if [ -n "{{ output_name | default('') }}" ]; then
           echo "Fetching specific output: {{ output_name }}"
-          sudo -E {{ pulumi_bin_path }} stack output {{ output_name }}
+          {{ pulumi_sudo_cmd }} stack output {{ output_name }}
         else
           echo "Fetching all outputs"
-          sudo -E {{ pulumi_bin_path }} stack output --json
+          {{ pulumi_sudo_cmd }} stack output --json
         fi
       register: stack_output_result
       changed_when: false

--- a/ansible/roles/pulumi_helper/tasks/init_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/init_stack.yml
@@ -1,5 +1,10 @@
 # スタックの初期化とセットアップのヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Initialize and set up Pulumi stack
   block:
     # 開始ログ
@@ -48,12 +53,10 @@
     - name: Initialize new stack if not exists
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
-        eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+        {{ pulumi_env_prefix }}
         
         echo "Creating new stack: {{ resolved_stack_name }}"
-        sudo -E {{ pulumi_bin_path }} stack init {{ resolved_stack_name }}
+        {{ pulumi_sudo_cmd }} stack init {{ resolved_stack_name }}
       register: stack_init_result
       changed_when: stack_init_result.rc == 0
       when: 
@@ -100,17 +103,15 @@
     - name: Select stack
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
-        eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+        {{ pulumi_env_prefix }}
         
         echo "Attempting to select stack..."
         # まず単純な名前で試し、失敗したら解決済み名前を使用
-        if sudo -E {{ pulumi_bin_path }} stack select {{ stack_name }} 2>/dev/null; then
+        if {{ pulumi_sudo_cmd }} stack select {{ stack_name }} 2>/dev/null; then
           echo "Selected with simple name: {{ stack_name }}"
         else
           echo "Simple name failed, trying resolved name: {{ resolved_stack_name }}"
-          sudo -E {{ pulumi_bin_path }} stack select {{ resolved_stack_name }}
+          {{ pulumi_sudo_cmd }} stack select {{ resolved_stack_name }}
           echo "Selected with resolved name: {{ resolved_stack_name }}"
         fi
       register: stack_select_result
@@ -127,8 +128,7 @@
     - name: Verify current stack
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name
       register: current_stack_verify
       changed_when: false
       when: not ansible_check_mode

--- a/ansible/roles/pulumi_helper/tasks/login.yml
+++ b/ansible/roles/pulumi_helper/tasks/login.yml
@@ -1,0 +1,100 @@
+# Pulumiの認証とトークン設定を一元管理するタスク
+# このファイルは各タスクの最初でincludeして使用します
+
+- name: Ensure Pulumi authentication
+  block:
+    # PULUMI_ACCESS_TOKENの確認
+    - name: Check for PULUMI_ACCESS_TOKEN in environment
+      ansible.builtin.set_fact:
+        pulumi_token_set: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') | length > 0 }}"
+        pulumi_access_token: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
+      no_log: true
+
+    - name: Fail if PULUMI_ACCESS_TOKEN is not set
+      ansible.builtin.fail:
+        msg: |
+          ERROR: PULUMI_ACCESS_TOKEN environment variable is not set.
+          Please set the PULUMI_ACCESS_TOKEN environment variable before running this playbook:
+          export PULUMI_ACCESS_TOKEN="pul-YOUR_ACCESS_TOKEN"
+      when: not pulumi_token_set
+
+    # Pulumiのパス設定
+    - name: Set Pulumi binary path if not already set
+      ansible.builtin.set_fact:
+        pulumi_bin_path: "/root/.pulumi/bin/pulumi"
+      when: pulumi_bin_path is not defined
+
+    # ログイン状態の確認
+    - name: Check current Pulumi login status
+      ansible.builtin.shell: |
+        export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
+        sudo -E {{ pulumi_bin_path }} whoami
+      register: pulumi_login_check
+      changed_when: false
+      failed_when: false
+      no_log: true
+
+    # ログインが必要な場合のみログイン実行
+    - name: Login to Pulumi if not already logged in
+      ansible.builtin.shell: |
+        export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
+        sudo -E {{ pulumi_bin_path }} login
+      when: pulumi_login_check.rc != 0
+      register: pulumi_login_result
+      changed_when: pulumi_login_result.rc == 0
+      no_log: true
+
+    # ログイン検証
+    - name: Verify Pulumi login successful
+      ansible.builtin.shell: |
+        export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
+        sudo -E {{ pulumi_bin_path }} whoami
+      register: pulumi_verify_login
+      changed_when: false
+      no_log: true
+
+    - name: Display Pulumi login status
+      ansible.builtin.debug:
+        msg: "Successfully authenticated to Pulumi as: {{ pulumi_verify_login.stdout }}"
+      when: ansible_verbosity > 0
+
+    # 環境変数をエクスポートする共通コマンドを定義
+    - name: Set Pulumi environment prefix
+      ansible.builtin.set_fact:
+        pulumi_env_prefix: >-
+          export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}";
+          source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null &&
+          eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
+
+    # sudoを使用したPulumiコマンドのプレフィックス
+    - name: Set Pulumi sudo command prefix
+      ansible.builtin.set_fact:
+        pulumi_sudo_cmd: "sudo -E {{ pulumi_bin_path }}"
+
+  rescue:
+    - name: Handle authentication failure
+      ansible.builtin.fail:
+        msg: |
+          Failed to authenticate to Pulumi.
+          Please ensure:
+          1. PULUMI_ACCESS_TOKEN is correctly set
+          2. The token is valid and not expired
+          3. You have internet connectivity to reach Pulumi service
+          
+          Error details: {{ ansible_failed_result.msg | default('Unknown error') }}
+
+# チェックモード用の処理
+- name: Set mock authentication for check mode
+  when: ansible_check_mode
+  block:
+    - name: Set mock values for check mode
+      ansible.builtin.set_fact:
+        pulumi_token_set: true
+        pulumi_access_token: "mock-token-for-check-mode"
+        pulumi_env_prefix: "export PULUMI_ACCESS_TOKEN='mock-token-for-check-mode'"
+        pulumi_sudo_cmd: "sudo -E /root/.pulumi/bin/pulumi"
+        pulumi_bin_path: "/root/.pulumi/bin/pulumi"
+
+    - name: Display check mode notice
+      ansible.builtin.debug:
+        msg: "Running in check mode - Pulumi authentication will be mocked"

--- a/ansible/roles/pulumi_helper/tasks/main.yml
+++ b/ansible/roles/pulumi_helper/tasks/main.yml
@@ -18,7 +18,7 @@
     mode: '0755'
   register: aws_env_script_perm
   failed_when: false
-  no_log: true  # 詳細出力を抑制
+  no_log: true
 
 - name: Report AWS script permissions update
   ansible.builtin.debug:
@@ -48,9 +48,9 @@
     msg: "Pulumi is not installed. Please run bootstrap setup first."
   when: not pulumi_check.stat.exists and not pulumi_root_check.stat.exists
 
-- name: Set Pulumi path
-  ansible.builtin.set_fact:
-    pulumi_bin_path: "/root/.pulumi/bin/pulumi"
+# Pulumi認証処理を実行
+- name: Handle Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
 
 # Pulumiのバージョン確認
 - name: Check Pulumi version
@@ -63,74 +63,18 @@
     msg: "Using Pulumi version: {{ pulumi_version.stdout }}"
   when: ansible_verbosity > 0
 
-# Pulumiのログイン状態確認
-- name: Check Pulumi login status
-  ansible.builtin.shell: |
-    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-    sudo -E {{ pulumi_bin_path }} whoami
-  register: pulumi_login_check
-  changed_when: false
-  failed_when: false
-  ignore_errors: true
-  
-- name: Display Pulumi login status
-  ansible.builtin.debug:
-    msg: "Pulumi login status: {{ 'Logged in as ' + pulumi_login_check.stdout if pulumi_login_check.rc == 0 else 'Not logged in' }}"
-
-# Pulumiログイン処理
-- name: Check for PULUMI_ACCESS_TOKEN in environment
-  ansible.builtin.set_fact:
-    pulumi_token_set: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') | length > 0 }}"
-
-- name: Login to Pulumi using access token from environment
-  ansible.builtin.shell: |
-    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-    sudo -E {{ pulumi_bin_path }} login
-  when: 
-    - pulumi_token_set 
-    - pulumi_login_check.rc != 0
-  register: pulumi_login_result
-  changed_when: pulumi_login_result.rc == 0
-  no_log: true  # 認証情報が含まれる可能性があるため、ログに出力しない
-
-- name: Warn about Pulumi login requirement
-  ansible.builtin.debug:
-    msg: >
-      WARNING: Pulumi is not logged in and no PULUMI_ACCESS_TOKEN environment variable was found.
-      Please set the PULUMI_ACCESS_TOKEN environment variable before running this playbook:
-      export PULUMI_ACCESS_TOKEN="pul-YOUR_ACCESS_TOKEN"
-  when: 
-    - not pulumi_token_set 
-    - pulumi_login_check.rc != 0
-
-- name: Verify Pulumi login after attempts
-  ansible.builtin.shell: |
-    export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-    sudo -E {{ pulumi_bin_path }} whoami
-  register: pulumi_verify_login
-  failed_when: 
-    - pulumi_token_set 
-    - pulumi_verify_login.rc != 0
-  changed_when: false
-  when: pulumi_token_set
-  
-- name: Display Pulumi login verification
-  ansible.builtin.debug:
-    msg: "Pulumi login verified: {{ pulumi_verify_login.stdout if pulumi_verify_login.rc == 0 else 'Failed to verify login' }}"
-  when: pulumi_token_set
-
-# Pulumiコマンド定義（PULUMI_ACCESS_TOKENを含むように修正）
+# Pulumiコマンド定義（pulumi_env_prefixとpulumi_sudo_cmdを使用）
 - name: Set Pulumi standard tasks
   ansible.builtin.set_fact:
     pulumi_commands:
-      preview:      "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} preview"
-      up:           "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} up --yes"
-      destroy:      "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} destroy --yes"
-      refresh:      "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} refresh --yes"
-      stack_output: "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack output"
-      stack_ls:     "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack ls"
-      stack_rm:     "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} stack rm --yes"
-      config_set:   "export PULUMI_ACCESS_TOKEN=\"{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}\"; source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null && eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null && sudo -E {{ pulumi_bin_path }} config set"
+      preview:      "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} preview"
+      up:           "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} up --yes"
+      destroy:      "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} destroy --yes"
+      refresh:      "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} refresh --yes"
+      stack_output: "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack output"
+      stack_ls:     "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack ls"
+      stack_rm:     "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack rm --yes"
+      config_set:   "{{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} config set"
       build:        "npm run build"
       tsc:          "npx tsc"
 

--- a/ansible/roles/pulumi_helper/tasks/preview.yml
+++ b/ansible/roles/pulumi_helper/tasks/preview.yml
@@ -1,13 +1,17 @@
 # Pulumiのプレビュー実行ヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Preview Pulumi deployment
   block:
     # スタックが選択されているか確認
     - name: Ensure stack is selected
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name || exit 1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name || exit 1
       register: current_stack
       changed_when: false
       failed_when: current_stack.rc != 0

--- a/ansible/roles/pulumi_helper/tasks/refresh.yml
+++ b/ansible/roles/pulumi_helper/tasks/refresh.yml
@@ -1,13 +1,17 @@
 # Pulumiスタックをリフレッシュするヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Refresh Pulumi stack
   block:
     # スタックが選択されているか確認
     - name: Ensure stack is selected
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name || exit 1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name || exit 1
       register: current_stack
       changed_when: false
       failed_when: current_stack.rc != 0

--- a/ansible/roles/pulumi_helper/tasks/remove_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/remove_stack.yml
@@ -1,5 +1,10 @@
 # Pulumiスタックを削除するヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Remove Pulumi stack
   block:
     # スタック名の検証
@@ -16,9 +21,8 @@
     - name: Find stack to remove
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
         # スタック名で終わるものを検索
-        sudo -E {{ pulumi_bin_path }} stack ls --json | jq -r '.[].name | select(endswith("/{{ stack_name }}") or . == "{{ stack_name }}")' | head -1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack ls --json | jq -r '.[].name | select(endswith("/{{ stack_name }}") or . == "{{ stack_name }}")' | head -1
       register: found_stack
       changed_when: false
       when: not ansible_check_mode
@@ -37,8 +41,7 @@
         cd {{ pulumi_project_path }}
         source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
         eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack rm --yes "{{ found_stack.stdout | trim }}"
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack rm --yes "{{ found_stack.stdout | trim }}"
       register: stack_rm_result
       changed_when: stack_rm_result.rc == 0
       when: 

--- a/ansible/roles/pulumi_helper/tasks/resolve_stack_name.yml
+++ b/ansible/roles/pulumi_helper/tasks/resolve_stack_name.yml
@@ -2,6 +2,11 @@
 # 入力: stack_name (例: dev)
 # 出力: resolved_stack_name (例: myorg/jenkins-agent/dev または dev)
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Display resolution start
   ansible.builtin.debug:
     msg: |

--- a/ansible/roles/pulumi_helper/tasks/set_config.yml
+++ b/ansible/roles/pulumi_helper/tasks/set_config.yml
@@ -1,5 +1,10 @@
 # Pulumiスタックの設定値を管理するヘルパータスク
 
+# 認証処理を実行
+- name: Ensure Pulumi authentication
+  ansible.builtin.include_tasks: login.yml
+  when: pulumi_access_token is not defined
+
 - name: Configure Pulumi stack
   block:
     # 必須変数の確認
@@ -12,8 +17,7 @@
     - name: Ensure stack is selected
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} stack --show-name || exit 1
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} stack --show-name || exit 1
       register: current_stack
       changed_when: false
       failed_when: current_stack.rc != 0
@@ -25,8 +29,7 @@
         cd {{ pulumi_project_path }}
         source {{ playbook_dir }}/../../scripts/aws-env.sh > /dev/null
         eval $({{ playbook_dir }}/../../scripts/aws-env.sh) > /dev/null
-        export PULUMI_ACCESS_TOKEN="{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-        sudo -E {{ pulumi_bin_path }} config set {{ config_key }} "{{ config_value }}" {{ '--secret' if config_secret | default(false) else '' }}
+        {{ pulumi_env_prefix }} && {{ pulumi_sudo_cmd }} config set {{ config_key }} "{{ config_value }}" {{ '--secret' if config_secret | default(false) else '' }}
       register: config_result
       changed_when: config_result.rc == 0
       when: not ansible_check_mode


### PR DESCRIPTION
Centralizes Pulumi authentication logic into a new login.yml task and includes it at the start of all relevant tasks. Replaces direct environment variable and sudo handling with reusable pulumi_env_prefix and pulumi_sudo_cmd variables, improving maintainability and consistency across all Pulumi helper tasks.