### PR TITLE
Jenkins: ansible-playbook-executorをec2-fleetエージェントに移行

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_ansible_playbook_executor_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_ansible_playbook_executor_job.groovy
@@ -116,23 +116,6 @@ ${playbookListText}
                 
                 // 実行制御
                 booleanParam('DRY_RUN', false, '実行コマンドの確認のみ（実際には実行しない）')
-                
-                // tmux実行オプション（設定で有効な場合のみ表示）
-                if (playbookConfig.enable_tmux ?: playbookConfig.enable_nohup) {
-                    booleanParam('USE_TMUX', playbookConfig.enable_tmux ?: playbookConfig.enable_nohup, 
-                        'tmuxセッションでバックグラウンド実行\n長時間実行のプレイブックで推奨、リアルタイムログ確認可能')
-                    
-                    def timeoutMinutes = playbookConfig.tmux_timeout_minutes ?: playbookConfig.nohup_timeout_minutes ?: 60
-                    stringParam('TMUX_TIMEOUT_MINUTES', timeoutMinutes.toString(), 
-                        'tmux実行時のタイムアウト時間（分）')
-                    
-                    // 複数プレイブックの場合、タイムアウト時の動作を追加
-                    if (playbookPaths.size() > 1) {
-                        def continueOnTimeout = playbookConfig.continue_on_timeout ?: false
-                        booleanParam('CONTINUE_ON_TIMEOUT', continueOnTimeout, 
-                            'タイムアウト時も次のプレイブックを続行\n⚠️ 注意: タイムアウトしたプレイブックの処理は不完全な可能性があります')
-                    }
-                }
             }
             
             // ログローテーション設定

--- a/jenkins/jobs/pipeline/infrastructure/ansible-playbook-executor/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/ansible-playbook-executor/Jenkinsfile
@@ -4,7 +4,7 @@
 
 // Ansibleプレイブック設定の読み込み
 def loadPlaybookConfig() {
-    def configFile = readYaml file: 'jenkins/jobs/pipeline/_seed/job-creator/job-config.yaml'
+    def configFile = readYaml file: "${env.INFRA_REPO_DIR}/jenkins/jobs/pipeline/_seed/job-creator/job-config.yaml"
     return configFile['ansible-playbooks']['infrastructure-as-code']['playbooks']
 }
 
@@ -25,11 +25,6 @@ def resolvePlaybookPath(String playbookName, def playbooksConfig) {
     error("プレイブック '${playbookName}' が設定に見つかりません")
 }
 
-// tmuxセッション名を生成
-def generateTmuxSessionName() {
-    def jobNameShort = env.JOB_NAME.split('/')[-1].replaceAll('[^a-zA-Z0-9_-]', '_').take(20)
-    return "ansible_${jobNameShort}_${env.BUILD_NUMBER}"
-}
 
 // Ansibleコマンドを構築
 def buildAnsibleCommand(playbook, params) {
@@ -86,7 +81,7 @@ def buildAnsibleCommand(playbook, params) {
 
 pipeline {
     agent {
-        label 'bootstrap-workterminal'
+        label 'ec2-fleet'
     }
     
     options {
@@ -97,7 +92,11 @@ pipeline {
     }
     
     environment {
-        ANSIBLE_BASE_DIR = "${WORKSPACE}/ansible"
+        // リポジトリディレクトリ
+        INFRA_REPO_DIR = "${WORKSPACE}/infrastructure-as-code"
+        
+        // Ansible設定
+        ANSIBLE_BASE_DIR = "${INFRA_REPO_DIR}/ansible"
         ANSIBLE_INVENTORY = "${ANSIBLE_BASE_DIR}/inventory"
         ANSIBLE_PLAYBOOKS_DIR = "${ANSIBLE_BASE_DIR}/playbooks"
         ANSIBLE_FORCE_COLOR = 'true'
@@ -124,7 +123,6 @@ pipeline {
                     タグ: ${params.ANSIBLE_TAGS}
                     スキップタグ: ${params.ANSIBLE_SKIP_TAGS}
                     ドライラン: ${params.DRY_RUN}
-                    tmuxモード: ${params.USE_TMUX}
                     ========================================
                     """
                     
@@ -136,17 +134,21 @@ pipeline {
             }
         }
         
-        stage('リポジトリ更新') {
+        stage('リポジトリチェックアウト') {
             steps {
                 script {
-                    echo "Workterminalのリポジトリを更新中..."
+                    echo "リポジトリをチェックアウト中..."
                     
-                    // リポジトリの更新（CIモードで実行）
-                    sh """
-                        cd ~/infrastructure-as-code
-                        chmod +x scripts/workterminal/update-repo-branch.sh
-                        ./scripts/workterminal/update-repo-branch.sh ${params.BRANCH} --ci
-                    """
+                    // infrastructure-as-codeリポジトリのチェックアウト
+                    dir(env.INFRA_REPO_DIR) {
+                        gitUtils.checkoutRepository(
+                            env.GIT_INFRASTRUCTURE_REPO_URL,
+                            params.BRANCH,
+                            env.GITHUB_APP_CREDENTIALS_ID
+                        )
+                    }
+                    
+                    echo "チェックアウト完了: ブランチ ${params.BRANCH}"
                 }
             }
         }
@@ -154,7 +156,7 @@ pipeline {
         stage('プレイブック解析') {
             steps {
                 script {
-                    // プレイブック設定の読み込み
+                    // プレイブック設定の読み込み（リポジトリチェックアウト後）
                     def playbooksConfig = loadPlaybookConfig()
                     
                     // プレイブックリストの解析
@@ -175,26 +177,6 @@ pipeline {
             steps {
                 script {
                     def playbookList = env.RESOLVED_PLAYBOOKS.split(',')
-                    def useTmux = params.USE_TMUX ?: false
-                    def tmuxTimeoutMinutes = params.TMUX_TIMEOUT_MINUTES ?: '60'
-                    def continueOnTimeout = params.CONTINUE_ON_TIMEOUT ?: false
-                    def timedOutPlaybooks = []
-                    
-                    // tmuxセッション名を生成（全プレイブックで共有）
-                    def tmuxSessionName = generateTmuxSessionName()
-                    env.tmuxSessionName = tmuxSessionName // post処理で使用
-                    env.useTmux = useTmux.toString()
-                    
-                    if (useTmux) {
-                        echo """
-                        ========================================
-                         tmuxモードで実行
-                        ========================================
-                        セッション名: ${tmuxSessionName}
-                        タイムアウト: ${tmuxTimeoutMinutes}分
-                        タイムアウト時の続行: ${continueOnTimeout ? '有効' : '無効'}
-                        """
-                    }
                     
                     playbookList.eachWithIndex { playbook, index ->
                         def stageName = "プレイブック ${index + 1}/${playbookList.size()}: ${playbook}"
@@ -218,84 +200,18 @@ pipeline {
                         if (params.DRY_RUN) {
                             echo "ドライランモード: 実際の実行はスキップされました"
                         } else {
-                            if (useTmux) {
-                                // tmuxで実行
-                                def windowName = "playbook_${index}"
-                                echo "tmuxセッション内で実行を開始します..."
-                                echo "セッション: ${tmuxSessionName}, ウィンドウ: ${windowName}"
                                 
-                                // 外部スクリプトを使用してtmux実行
-                                def exitCode = sh(
-                                    script: """
-                                        cd ~/infrastructure-as-code
-                                        chmod +x scripts/workterminal/run-ansible-in-tmux.sh
-                                        ./scripts/workterminal/run-ansible-in-tmux.sh \
-                                            "${tmuxSessionName}" \
-                                            "${windowName}" \
-                                            "${tmuxTimeoutMinutes}" \
-                                            "${ansibleCmd}"
-                                    """,
-                                    returnStatus: true
-                                )
                                 
-                                if (exitCode == 2) {
-                                    // タイムアウト
-                                    timedOutPlaybooks.add(playbook)
-                                    echo "⚠️ 警告: このプレイブックはタイムアウトしました"
-                                    
-                                    if (!continueOnTimeout && index < playbookList.size() - 1) {
-                                        error("タイムアウトのため実行を中止します")
-                                    }
-                                } else if (exitCode != 0) {
-                                    // その他のエラー
-                                    error("Ansibleの実行が失敗しました（終了コード: ${exitCode}）")
-                                }
-                                
-                                echo """
-                                ========================================
-                                 実行情報
-                                ========================================
-                                tmuxセッション: ${tmuxSessionName}
-                                ウィンドウ: ${windowName}
-                                
-                                ログ確認方法:
-                                1. リアルタイムログ表示:
-                                   tmux attach -t ${tmuxSessionName}
-                                   (終了: Ctrl+b, d でデタッチ)
-                                
-                                2. ログファイル:
-                                   /tmp/${tmuxSessionName}_${windowName}.log
-                                ========================================
-                                """
-                            } else {
-                                // 通常実行
-                                sh """
-                                    cd ~/infrastructure-as-code/ansible
-                                    ${ansibleCmd}
-                                """
-                            }
+                            // Ansible実行
+                            sh """
+                                cd ${ANSIBLE_BASE_DIR}
+                                ${ansibleCmd}
+                            """
                         }
                         
                         if (index < playbookList.size() - 1) {
                             echo "次のプレイブックに進みます..."
                         }
-                    }
-                    
-                    // タイムアウトサマリーの表示
-                    if (timedOutPlaybooks.size() > 0) {
-                        echo """
-                        ========================================
-                         ⚠️ タイムアウト警告
-                        ========================================
-                        以下のプレイブックがタイムアウトしました:
-                        ${timedOutPlaybooks.collect { "  - ${it}" }.join('\n')}
-                        
-                        これらのプレイブックは完全に実行されていない可能性があります。
-                        ログファイルを確認して、必要に応じて再実行してください。
-                        ========================================
-                        """
-                        
-                        currentBuild.result = 'UNSTABLE'
                     }
                 }
             }
@@ -304,24 +220,12 @@ pipeline {
     
     post {
         success {
-            script {
-                if (currentBuild.result == 'UNSTABLE') {
-                    echo """
-                    ========================================
-                     Ansible実行完了（警告あり）
-                    ========================================
-                    実行は完了しましたが、一部のプレイブックが
-                    タイムアウトしました。詳細は上記の警告を確認してください。
-                    """
-                } else {
-                    echo """
-                    ========================================
-                     Ansible実行成功
-                    ========================================
-                    すべてのプレイブックが正常に実行されました。
-                    """
-                }
-            }
+            echo """
+            ========================================
+             Ansible実行成功
+            ========================================
+            すべてのプレイブックが正常に実行されました。
+            """
         }
         
         failure {
@@ -335,23 +239,6 @@ pipeline {
         }
         
         always {
-            script {
-                // tmuxセッションのクリーンアップ
-                if (env.useTmux == 'true' && env.tmuxSessionName) {
-                    sh """
-                        # tmuxセッションが存在する場合は削除
-                        if tmux has-session -t ${env.tmuxSessionName} 2>/dev/null; then
-                            echo "tmuxセッション '${env.tmuxSessionName}' をクリーンアップしています..."
-                            tmux kill-session -t ${env.tmuxSessionName}
-                            echo "tmuxセッションをクリーンアップしました"
-                        fi
-                        
-                        # 一時ファイルのクリーンアップ
-                        rm -f /tmp/${env.tmuxSessionName}_*.log
-                        rm -f /tmp/${env.tmuxSessionName}_*.log.timeout
-                    """ 
-                }
-            }
             cleanWs()
         }
     }


### PR DESCRIPTION
## 概要
ansible-playbook-executorジョブをbootstrap-workterminalからec2-fleetエージェントに移行し、tmuxモードを削除しました。

## 変更内容

### 1. エージェントの変更
- `bootstrap-workterminal` → `ec2-fleet` に変更
- EC2 FleetエージェントにAnsibleがインストールされたため移行が可能に

### 2. リポジトリチェックアウト処理の追加
- `gitUtils.checkoutRepository()` を使用したチェックアウト処理を実装
- 毎回新規にリポジトリをチェックアウトすることで、クリーンな環境での実行を保証

### 3. tmuxモードの完全削除
- tmux関連のコード、パラメータ、変数をすべて削除
- シンプルな直接実行方式に変更
- DSLファイルからもtmux関連パラメータを削除

### 4. パスの統一
- すべてのパスを `INFRA_REPO_DIR` ベースに統一
- ワークスペース相対パスを使用することで環境依存を排除

## 変更ファイル
- `jenkins/jobs/pipeline/infrastructure/ansible-playbook-executor/Jenkinsfile`
- `jenkins/jobs/dsl/infrastructure/infrastructure_ansible_playbook_executor_job.groovy`

## テスト確認項目
- [x] ec2-fleetエージェントでのAnsible実行
- [x] リポジトリチェックアウトの動作
- [x] 各種プレイブックの実行
- [x] エラーハンドリング

## 影響範囲
- ansible-playbook-executorジョブが新しいエージェントで実行されるように
- tmux関連のパラメータは無視される（後方互換性は保持）

## 関連Issue
- #133