### PR TITLE
[ansible] fix: jenkins_cleanup_agent_amisロールのinclude_roleでfailed_when…

### DIFF
--- a/ansible/roles/jenkins_cleanup_agent_amis/tasks/verify_deletion.yml
+++ b/ansible/roles/jenkins_cleanup_agent_amis/tasks/verify_deletion.yml
@@ -26,7 +26,6 @@
           loop_control:
             label: "{{ item.Name }} ({{ item.ImageId }})"
           register: ami_verification_results
-          failed_when: false  # エラーを無視（削除済みの場合エラーになるため）
 
         - name: Check AMI deletion results
           ansible.builtin.set_fact:
@@ -65,7 +64,6 @@
           loop_control:
             label: "{{ item.snapshot_id }}"
           register: snapshot_verification_results
-          failed_when: false  # エラーを無視（削除済みの場合エラーになるため）
 
         - name: Check snapshot deletion results
           ansible.builtin.set_fact:


### PR DESCRIPTION
…属性エラーを修正

include_roleタスクでは failed_when 属性を直接使用できないため、
verify_deletion.yml から該当属性を削除。
削除済みリソースの確認時のエラーは後続タスクで適切に処理される。