### PR TITLE
[jenkins] update: Jenkins Agentインスタンスタイプをmediumサイズに変更

### DIFF
--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent.yml
@@ -14,10 +14,11 @@
     # コマンドラインから環境名を受け取る
     env_name: "{{ env | default('dev') }}"
     # エージェント設定 - 再帰参照を避けるために変数名を変更
-    agent_instance_type_param: "{{ instance_type | default('t3.medium') }}"
+    agent_instance_type_param: "{{ instance_type | default('t3a.medium') }}"
     agent_min_capacity_param: "{{ min_capacity | default(0) }}"
     agent_max_capacity_param: "{{ max_capacity | default(10) }}"
-    agent_spot_price_param: "{{ spot_price | default('0.10') }}"
+    # Spot価格上限をオンデマンド価格に設定（ap-northeast-1）
+    agent_spot_price_param: "{{ spot_price | default('0.052') }}"
 
   pre_tasks:
     # all.yml から変数を読み込む

--- a/ansible/roles/jenkins_agent/defaults/main.yml
+++ b/ansible/roles/jenkins_agent/defaults/main.yml
@@ -8,7 +8,9 @@ pulumi_path: "{{ inventory_dir }}/../../pulumi"
 env_name: "dev"
 
 # エージェント設定のデフォルト値
-instance_type: "t3.medium"
+instance_type: "t3a.medium"
 min_capacity: 0
 max_capacity: 10
-spot_price: "0.10"
+# Spot価格上限をオンデマンド価格に設定（ap-northeast-1リージョン）
+# t3a.medium: ~$0.047/h, t3.medium: ~$0.052/h, t4g.medium: ~$0.042/h
+spot_price: "0.052"

--- a/pulumi/jenkins-agent/index.ts
+++ b/pulumi/jenkins-agent/index.ts
@@ -230,7 +230,7 @@ const spotFleetRole = new aws.iam.Role(`spotfleet-role`, {
 const agentLaunchTemplate = new aws.ec2.LaunchTemplate(`agent-lt`, {
     namePrefix: `jenkins-infra-agent-lt-`,
     imageId: amiX86Id,
-    instanceType: "t3.small", // デフォルトをt3.smallに変更
+    instanceType: "t3a.medium", // デフォルトをt3a.mediumに変更（AMDプロセッサで10%安価）
     keyName: agentKeyPair.keyName,  // 作成したキーペアを使用
     // vpcSecurityGroupIds は networkInterfaces と競合するため削除
     iamInstanceProfile: {
@@ -379,7 +379,7 @@ chown jenkins:jenkins /home/jenkins/agent/bootstrap-complete
 const agentLaunchTemplateArm = new aws.ec2.LaunchTemplate(`agent-lt-arm`, {
     namePrefix: `jenkins-infra-agent-lt-arm-`,
     imageId: amiArmId,
-    instanceType: "t4g.small",
+    instanceType: "t4g.medium",
     keyName: agentKeyPair.keyName,
     // vpcSecurityGroupIds は networkInterfaces と競合するため削除
     iamInstanceProfile: {
@@ -533,7 +533,7 @@ const spotFleetRequest = new aws.ec2.SpotFleetRequest(`agent-spot-fleet`, {
                 },
                 overrides: [{
                     subnetId: subnetId,
-                    instanceType: "t4g.small",
+                    instanceType: "t4g.medium",
                     spotPrice: spotPrice,
                     priority: 1, // 最優先
                 }],
@@ -550,13 +550,13 @@ const spotFleetRequest = new aws.ec2.SpotFleetRequest(`agent-spot-fleet`, {
                 overrides: [
                     {
                         subnetId: subnetId,
-                        instanceType: "t3.small",
+                        instanceType: "t3a.medium",
                         spotPrice: spotPrice,
                         priority: 2,
                     },
                     {
                         subnetId: subnetId,
-                        instanceType: "t2.small",
+                        instanceType: "t3.medium",
                         spotPrice: spotPrice,
                         priority: 3,
                     }


### PR DESCRIPTION
- インスタンスタイプをsmallからmediumにアップグレード
  - t3.small → t3a.medium (AMDプロセッサで10%安価)
  - t4g.small → t4g.medium (ARM)
  - t2.small → t3.medium (t2を廃止し、t3をフォールバック用に)
- Spot価格上限をオンデマンド価格に設定 ($0.052/時間)
  - 中断リスクを最小化しつつコスト削減を実現
- インスタンスタイプの優先順位を最適化
  1. t4g.medium (ARM、最も安価)
  2. t3a.medium (AMD、t3より10%安価)
  3. t3.medium (Intel、フォールバック)