### PR TITLE
[pulumi] fix: Lambda NAT設定で両方のリソースが作成される問題を修正 (#162)

### DIFF
--- a/pulumi/lambda-nat/components/nat-gateway.ts
+++ b/pulumi/lambda-nat/components/nat-gateway.ts
@@ -246,6 +246,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
         value: "gateway-ha",
         description: "NAT type (gateway-ha)",
         tags: commonTags,
+        overwrite: true,
     });
 
     // NAT設定情報を保存
@@ -262,6 +263,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
         })),
         description: "NAT Gateway configuration for Lambda API infrastructure",
         tags: commonTags,
+        overwrite: true,
     });
 
     // コスト最適化情報のパラメータ
@@ -280,6 +282,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
         }),
         description: "Cost optimization information for NAT Gateway configuration",
         tags: commonTags,
+        overwrite: true,
     });
 
     // デプロイメント完了フラグ
@@ -289,6 +292,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
         value: "true",
         description: "NAT Gateway stack deployment completion flag",
         tags: commonTags,
+        overwrite: true,
     });
 
     return {

--- a/pulumi/lambda-nat/components/nat-gateway.ts
+++ b/pulumi/lambda-nat/components/nat-gateway.ts
@@ -1,0 +1,301 @@
+/**
+ * components/nat-gateway.ts
+ * 
+ * NAT Gateway（高可用性モード）用のコンポーネント
+ * 2つのAZにNAT Gatewayを配置してHA構成を実現
+ */
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+/**
+ * NAT Gateway構成の入力パラメータ
+ */
+export interface NatGatewayArgs {
+    /** プロジェクト名 */
+    projectName: pulumi.Output<string>;
+    /** 環境名 */
+    environment: string;
+    /** パブリックサブネットA ID */
+    publicSubnetAId: pulumi.Output<string>;
+    /** パブリックサブネットB ID */
+    publicSubnetBId: pulumi.Output<string>;
+    /** プライベートルートテーブルA ID */
+    privateRouteTableAId: pulumi.Output<string>;
+    /** プライベートルートテーブルB ID */
+    privateRouteTableBId: pulumi.Output<string>;
+    /** 共通タグ */
+    commonTags: Record<string, string>;
+}
+
+/**
+ * NAT Gateway構成の出力
+ */
+export interface NatGatewayOutputs {
+    /** NAT Gateway A ID */
+    natGatewayAId: pulumi.Output<string>;
+    /** NAT Gateway B ID */
+    natGatewayBId: pulumi.Output<string>;
+    /** NAT Gateway A Elastic IP */
+    natGatewayEipAAddress: pulumi.Output<string>;
+    /** NAT Gateway B Elastic IP */
+    natGatewayEipBAddress: pulumi.Output<string>;
+    /** NAT リソースID配列 */
+    natResourceIds: pulumi.Output<string>[];
+}
+
+/**
+ * NAT Gateway（高可用性モード）を作成
+ * 
+ * @param args NAT Gateway構成パラメータ
+ * @returns NAT Gatewayリソース情報
+ */
+export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
+    const {
+        projectName,
+        environment,
+        publicSubnetAId,
+        publicSubnetBId,
+        privateRouteTableAId,
+        privateRouteTableBId,
+        commonTags
+    } = args;
+
+    // ========================================
+    // NAT Gateway A（AZ-a）
+    // ========================================
+    // Elastic IP for NAT Gateway A
+    const natGatewayEipA = new aws.ec2.Eip("nat-eip-a", {
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-eip-a-${environment}`,
+            Type: "nat-gateway",
+            AZ: "a",
+        },
+    });
+
+    // NAT Gateway A
+    const natGatewayA = new aws.ec2.NatGateway("nat-a", {
+        allocationId: natGatewayEipA.id,
+        subnetId: publicSubnetAId,
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-a-${environment}`,
+            Type: "nat-gateway",
+            AZ: "a",
+        },
+    });
+
+    // プライベートサブネットAからのルート
+    new aws.ec2.Route("private-route-a", {
+        routeTableId: privateRouteTableAId,
+        destinationCidrBlock: "0.0.0.0/0",
+        natGatewayId: natGatewayA.id,
+    }, {
+        dependsOn: [natGatewayA],
+    });
+
+    // ========================================
+    // NAT Gateway B（AZ-b）
+    // ========================================
+    // Elastic IP for NAT Gateway B
+    const natGatewayEipB = new aws.ec2.Eip("nat-eip-b", {
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-eip-b-${environment}`,
+            Type: "nat-gateway",
+            AZ: "b",
+        },
+    });
+
+    // NAT Gateway B
+    const natGatewayB = new aws.ec2.NatGateway("nat-b", {
+        allocationId: natGatewayEipB.id,
+        subnetId: publicSubnetBId,
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-b-${environment}`,
+            Type: "nat-gateway",
+            AZ: "b",
+        },
+    });
+
+    // プライベートサブネットBからのルート
+    new aws.ec2.Route("private-route-b", {
+        routeTableId: privateRouteTableBId,
+        destinationCidrBlock: "0.0.0.0/0",
+        natGatewayId: natGatewayB.id,
+    }, {
+        dependsOn: [natGatewayB],
+    });
+
+    // ========================================
+    // CloudWatchアラーム（モニタリング）
+    // ========================================
+    // NAT Gateway Aのパケットドロップアラーム
+    new aws.cloudwatch.MetricAlarm("nat-gateway-a-packet-drop", {
+        alarmDescription: "Alert when NAT Gateway A drops packets",
+        metricName: "PacketDropCount",
+        namespace: "AWS/NATGateway",
+        statistic: "Sum",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 100,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            NatGatewayId: natGatewayA.id,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    // NAT Gateway Bのパケットドロップアラーム
+    new aws.cloudwatch.MetricAlarm("nat-gateway-b-packet-drop", {
+        alarmDescription: "Alert when NAT Gateway B drops packets",
+        metricName: "PacketDropCount",
+        namespace: "AWS/NATGateway",
+        statistic: "Sum",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 100,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            NatGatewayId: natGatewayB.id,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    // 接続数アラーム（高負荷検知）
+    new aws.cloudwatch.MetricAlarm("nat-gateway-a-connections", {
+        alarmDescription: "Alert when NAT Gateway A has high connection count",
+        metricName: "ActiveConnectionCount",
+        namespace: "AWS/NATGateway",
+        statistic: "Max",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 50000, // NAT Gatewayの制限に近い値
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            NatGatewayId: natGatewayA.id,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    new aws.cloudwatch.MetricAlarm("nat-gateway-b-connections", {
+        alarmDescription: "Alert when NAT Gateway B has high connection count",
+        metricName: "ActiveConnectionCount",
+        namespace: "AWS/NATGateway",
+        statistic: "Max",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 50000,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            NatGatewayId: natGatewayB.id,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    // ========================================
+    // SSMパラメータへの保存
+    // ========================================
+    const paramPrefix = pulumi.interpolate`/${projectName}/${environment}/nat`;
+
+    // NAT Gateway A IDを保存
+    new aws.ssm.Parameter("nat-gateway-a-id", {
+        name: pulumi.interpolate`${paramPrefix}/gateway/a-id`,
+        type: "String",
+        value: natGatewayA.id,
+        description: "NAT Gateway A ID",
+        tags: commonTags,
+    });
+
+    // NAT Gateway B IDを保存
+    new aws.ssm.Parameter("nat-gateway-b-id", {
+        name: pulumi.interpolate`${paramPrefix}/gateway/b-id`,
+        type: "String",
+        value: natGatewayB.id,
+        description: "NAT Gateway B ID",
+        tags: commonTags,
+    });
+
+    // NAT Gateway A Elastic IPを保存
+    new aws.ssm.Parameter("nat-gateway-eip-a", {
+        name: pulumi.interpolate`${paramPrefix}/gateway/eip-a`,
+        type: "String",
+        value: natGatewayEipA.publicIp,
+        description: "NAT Gateway A Elastic IP",
+        tags: commonTags,
+    });
+
+    // NAT Gateway B Elastic IPを保存
+    new aws.ssm.Parameter("nat-gateway-eip-b", {
+        name: pulumi.interpolate`${paramPrefix}/gateway/eip-b`,
+        type: "String",
+        value: natGatewayEipB.publicIp,
+        description: "NAT Gateway B Elastic IP",
+        tags: commonTags,
+    });
+
+    // NATタイプを保存
+    new aws.ssm.Parameter("nat-type-gateway", {
+        name: pulumi.interpolate`${paramPrefix}/type`,
+        type: "String",
+        value: "gateway-ha",
+        description: "NAT type (gateway-ha)",
+        tags: commonTags,
+    });
+
+    // NAT設定情報を保存
+    new aws.ssm.Parameter("nat-config-gateway", {
+        name: pulumi.interpolate`${paramPrefix}/config`,
+        type: "String",
+        value: pulumi.output(projectName).apply(proj => JSON.stringify({
+            type: "gateway-ha",
+            highAvailability: true,
+            instanceType: "N/A",
+            projectName: proj,
+            environment: environment,
+            createdAt: new Date().toISOString(),
+        })),
+        description: "NAT Gateway configuration for Lambda API infrastructure",
+        tags: commonTags,
+    });
+
+    // コスト最適化情報のパラメータ
+    new aws.ssm.Parameter("nat-cost-info-gateway", {
+        name: `/lambda-api/${environment}/nat/cost-optimization`,
+        type: "String",
+        value: JSON.stringify({
+            estimatedMonthlyCost: "$90 (NAT Gateway x2)",
+            recommendations: [
+                "Monitor data transfer costs using CloudWatch",
+                "Consider VPC endpoints for AWS services to reduce NAT traffic",
+                "Consider NAT Instance for dev/staging to reduce costs",
+                "Enable detailed billing reports for accurate cost tracking"
+            ],
+            dataTransferThreshold: "> 100GB/month",
+        }),
+        description: "Cost optimization information for NAT Gateway configuration",
+        tags: commonTags,
+    });
+
+    // デプロイメント完了フラグ
+    new aws.ssm.Parameter("nat-deployed-gateway", {
+        name: pulumi.interpolate`${paramPrefix}/deployment/complete`,
+        type: "String",
+        value: "true",
+        description: "NAT Gateway stack deployment completion flag",
+        tags: commonTags,
+    });
+
+    return {
+        natGatewayAId: natGatewayA.id,
+        natGatewayBId: natGatewayB.id,
+        natGatewayEipAAddress: natGatewayEipA.publicIp,
+        natGatewayEipBAddress: natGatewayEipB.publicIp,
+        natResourceIds: [natGatewayA.id, natGatewayB.id],
+    };
+}

--- a/pulumi/lambda-nat/components/nat-gateway.ts
+++ b/pulumi/lambda-nat/components/nat-gateway.ts
@@ -240,7 +240,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
     });
 
     // NATタイプを保存
-    new aws.ssm.Parameter("nat-type-gateway", {
+    new aws.ssm.Parameter("nat-type", {
         name: pulumi.interpolate`${paramPrefix}/type`,
         type: "String",
         value: "gateway-ha",
@@ -249,7 +249,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
     });
 
     // NAT設定情報を保存
-    new aws.ssm.Parameter("nat-config-gateway", {
+    new aws.ssm.Parameter("nat-config", {
         name: pulumi.interpolate`${paramPrefix}/config`,
         type: "String",
         value: pulumi.output(projectName).apply(proj => JSON.stringify({
@@ -265,7 +265,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
     });
 
     // コスト最適化情報のパラメータ
-    new aws.ssm.Parameter("nat-cost-info-gateway", {
+    new aws.ssm.Parameter("nat-cost-info", {
         name: `/lambda-api/${environment}/nat/cost-optimization`,
         type: "String",
         value: JSON.stringify({
@@ -283,7 +283,7 @@ export function createNatGateway(args: NatGatewayArgs): NatGatewayOutputs {
     });
 
     // デプロイメント完了フラグ
-    new aws.ssm.Parameter("nat-deployed-gateway", {
+    new aws.ssm.Parameter("nat-deployed", {
         name: pulumi.interpolate`${paramPrefix}/deployment/complete`,
         type: "String",
         value: "true",

--- a/pulumi/lambda-nat/components/nat-instance.ts
+++ b/pulumi/lambda-nat/components/nat-instance.ts
@@ -241,6 +241,7 @@ The script should be located in the 'scripts' directory relative to your project
             deleteOnTermination: true,
         },
         metadataOptions: {
+            httpEndpoint: "enabled",
             httpTokens: "required", // IMDSv2を強制
             httpPutResponseHopLimit: 1,
         },
@@ -405,7 +406,7 @@ The script should be located in the 'scripts' directory relative to your project
     });
 
     // NATタイプを保存
-    new aws.ssm.Parameter("nat-type-instance", {
+    new aws.ssm.Parameter("nat-type", {
         name: pulumi.interpolate`${paramPrefix}/type`,
         type: "String",
         value: "instance",
@@ -414,7 +415,7 @@ The script should be located in the 'scripts' directory relative to your project
     });
 
     // NAT設定情報を保存
-    new aws.ssm.Parameter("nat-config-instance", {
+    new aws.ssm.Parameter("nat-config", {
         name: pulumi.interpolate`${paramPrefix}/config`,
         type: "String",
         value: pulumi.all([natInstanceType, projectName]).apply(([instanceType, proj]) => JSON.stringify({
@@ -430,7 +431,7 @@ The script should be located in the 'scripts' directory relative to your project
     });
 
     // コスト最適化情報のパラメータ
-    new aws.ssm.Parameter("nat-cost-info-instance", {
+    new aws.ssm.Parameter("nat-cost-info", {
         name: `/lambda-api/${environment}/nat/cost-optimization`,
         type: "String",
         value: natInstanceType.apply(instanceType => JSON.stringify({
@@ -449,7 +450,7 @@ The script should be located in the 'scripts' directory relative to your project
     });
 
     // デプロイメント完了フラグ
-    new aws.ssm.Parameter("nat-deployed-instance", {
+    new aws.ssm.Parameter("nat-deployed", {
         name: pulumi.interpolate`${paramPrefix}/deployment/complete`,
         type: "String",
         value: "true",

--- a/pulumi/lambda-nat/components/nat-instance.ts
+++ b/pulumi/lambda-nat/components/nat-instance.ts
@@ -412,6 +412,7 @@ The script should be located in the 'scripts' directory relative to your project
         value: "instance",
         description: "NAT type (instance)",
         tags: commonTags,
+        overwrite: true,
     });
 
     // NAT設定情報を保存
@@ -428,6 +429,7 @@ The script should be located in the 'scripts' directory relative to your project
         })),
         description: "NAT Instance configuration for Lambda API infrastructure",
         tags: commonTags,
+        overwrite: true,
     });
 
     // コスト最適化情報のパラメータ
@@ -447,6 +449,7 @@ The script should be located in the 'scripts' directory relative to your project
         })),
         description: "Cost optimization information for NAT Instance configuration",
         tags: commonTags,
+        overwrite: true,
     });
 
     // デプロイメント完了フラグ
@@ -456,6 +459,7 @@ The script should be located in the 'scripts' directory relative to your project
         value: "true",
         description: "NAT Instance stack deployment completion flag",
         tags: commonTags,
+        overwrite: true,
     });
 
     return {

--- a/pulumi/lambda-nat/components/nat-instance.ts
+++ b/pulumi/lambda-nat/components/nat-instance.ts
@@ -1,0 +1,466 @@
+/**
+ * components/nat-instance.ts
+ * 
+ * NAT Instance（通常モード）用のコンポーネント
+ * コスト最適化のため単一のNAT Instanceを使用
+ * Amazon Linux 2023 + nftablesベース
+ */
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as fs from "fs";
+import * as path from "path";
+
+// Node.jsグローバル変数の型定義を確実にするため
+declare const __dirname: string;
+declare const process: NodeJS.Process;
+
+/**
+ * NAT Instance構成の入力パラメータ
+ */
+export interface NatInstanceArgs {
+    /** プロジェクト名 */
+    projectName: pulumi.Output<string>;
+    /** 環境名 */
+    environment: string;
+    /** VPC CIDR */
+    vpcCidr: pulumi.Output<string>;
+    /** NAT Instanceタイプ */
+    natInstanceType: pulumi.Output<string>;
+    /** パブリックサブネットA ID */
+    publicSubnetAId: pulumi.Output<string>;
+    /** プライベートルートテーブルA ID */
+    privateRouteTableAId: pulumi.Output<string>;
+    /** プライベートルートテーブルB ID */
+    privateRouteTableBId: pulumi.Output<string>;
+    /** NAT Instance用セキュリティグループID */
+    natInstanceSecurityGroupId: pulumi.Output<string>;
+    /** 共通タグ */
+    commonTags: Record<string, string>;
+}
+
+/**
+ * NAT Instance構成の出力
+ */
+export interface NatInstanceOutputs {
+    /** NAT Instance ID */
+    natInstanceId: pulumi.Output<string>;
+    /** NAT Instance Public IP */
+    natInstancePublicIp: pulumi.Output<string>;
+    /** NAT Instance Private IP */
+    natInstancePrivateIp: pulumi.Output<string>;
+    /** NAT リソースID配列 */
+    natResourceIds: pulumi.Output<string>[];
+}
+
+/**
+ * NAT Instance（通常モード）を作成
+ * 
+ * @param args NAT Instance構成パラメータ
+ * @returns NAT Instanceリソース情報
+ */
+export function createNatInstance(args: NatInstanceArgs): NatInstanceOutputs {
+    const {
+        projectName,
+        environment,
+        vpcCidr,
+        natInstanceType,
+        publicSubnetAId,
+        privateRouteTableAId,
+        privateRouteTableBId,
+        natInstanceSecurityGroupId,
+        commonTags
+    } = args;
+
+    // ========================================
+    // AMI選択（ARM64/x86_64自動判定）
+    // ========================================
+    const isArmInstance = natInstanceType.apply(type => 
+        type.startsWith("t4g") || 
+        type.startsWith("m6g") || 
+        type.startsWith("m7g") ||
+        type.startsWith("c6g") ||
+        type.startsWith("c7g")
+    );
+    
+    // AMIは両方取得して後で選択
+    const armAmi = aws.ec2.getAmi({
+        mostRecent: true,
+        owners: ["amazon"],
+        filters: [{
+            name: "name",
+            values: ["al2023-ami-*-kernel-*-arm64"],
+        }],
+    });
+
+    const x86Ami = aws.ec2.getAmi({
+        mostRecent: true,
+        owners: ["amazon"],
+        filters: [{
+            name: "name",
+            values: ["al2023-ami-*-kernel-*-x86_64"],
+        }],
+    });
+
+    const natAmiId = isArmInstance.apply(isArm => 
+        isArm ? armAmi.then(ami => ami.id) : x86Ami.then(ami => ami.id)
+    );
+
+    // ========================================
+    // IAMロール設定
+    // ========================================
+    const natInstanceRole = new aws.iam.Role("nat-instance-role", {
+        assumeRolePolicy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [{
+                Action: "sts:AssumeRole",
+                Effect: "Allow",
+                Principal: {
+                    Service: "ec2.amazonaws.com",
+                },
+            }],
+        }),
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-instance-role-${environment}`,
+        },
+    });
+
+    // 必要な権限を付与
+    new aws.iam.RolePolicyAttachment("nat-instance-ssm-policy", {
+        role: natInstanceRole.name,
+        policyArn: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    });
+
+    new aws.iam.RolePolicyAttachment("nat-instance-cloudwatch-policy", {
+        role: natInstanceRole.name,
+        policyArn: "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+    });
+
+    // カスタムポリシー（メトリクス送信用）
+    const natInstancePolicy = new aws.iam.RolePolicy("nat-instance-custom-policy", {
+        role: natInstanceRole.name,
+        policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Effect: "Allow",
+                    Action: [
+                        "cloudwatch:PutMetricData",
+                        "ec2:DescribeInstances",
+                        "ec2:DescribeNetworkInterfaces",
+                    ],
+                    Resource: "*",
+                },
+            ],
+        }),
+    });
+
+    // インスタンスプロファイル
+    const natInstanceProfile = new aws.iam.InstanceProfile("nat-instance-profile", {
+        role: natInstanceRole.name,
+        tags: commonTags,
+    });
+
+    // ========================================
+    // Elastic IP
+    // ========================================
+    const natInstanceEip = new aws.ec2.Eip("nat-instance-eip", {
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-instance-eip-${environment}`,
+            Type: "nat-instance",
+        },
+    });
+
+    // ========================================
+    // ユーザーデータスクリプト
+    // ========================================
+    // NAT Instance用のユーザーデータスクリプトを外部ファイルから読み込み
+    const scriptPath = path.resolve(__dirname, '..', '..', '..', 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh');
+    let userDataTemplate: string;
+    
+    try {
+        // ファイルの存在確認
+        if (!fs.existsSync(scriptPath)) {
+            // 別の可能なパスを試す
+            const alternativePath = path.resolve(process.cwd(), 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh');
+            if (fs.existsSync(alternativePath)) {
+                userDataTemplate = fs.readFileSync(alternativePath, 'utf8');
+                pulumi.log.info(`Successfully loaded NAT instance setup script from alternative path: ${alternativePath}`);
+            } else {
+                throw new Error(`Script not found at ${scriptPath} or ${alternativePath}`);
+            }
+        } else {
+            userDataTemplate = fs.readFileSync(scriptPath, 'utf8');
+            pulumi.log.info(`Successfully loaded NAT instance setup script from: ${scriptPath}`);
+        }
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        pulumi.log.error(`Failed to read NAT instance setup script`);
+        pulumi.log.error(`Attempted path: ${scriptPath}`);
+        pulumi.log.error(`Current directory: ${process.cwd()}`);
+        pulumi.log.error(`__dirname: ${__dirname}`);
+        pulumi.log.error(`Error: ${errorMessage}`);
+        
+        // より詳細なヘルプメッセージ
+        pulumi.log.error(`
+Please ensure the NAT instance setup script exists at one of these locations:
+1. ${scriptPath}
+2. ${path.resolve(process.cwd(), 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh')}
+
+The script should be located in the 'scripts' directory relative to your project root.
+        `);
+        
+        throw new Error(`Cannot read NAT instance setup script: ${errorMessage}`);
+    }
+
+    // テンプレート変数を実際の値に置換
+    const userDataScript = pulumi.all([vpcCidr, projectName]).apply(([cidr, proj]) => {
+        return userDataTemplate
+            .replace(/\${VPC_CIDR}/g, cidr)
+            .replace(/\${PROJECT_NAME}/g, proj)
+            .replace(/\${ENVIRONMENT}/g, environment)
+            .replace(/\${AWS_REGION}/g, aws.config.region || 'ap-northeast-1');
+    });
+
+    // ========================================
+    // NAT Instance
+    // ========================================
+    const natInstance = new aws.ec2.Instance("nat-instance", {
+        ami: natAmiId,
+        instanceType: natInstanceType,
+        subnetId: publicSubnetAId,
+        vpcSecurityGroupIds: [natInstanceSecurityGroupId],
+        iamInstanceProfile: natInstanceProfile.name,
+        sourceDestCheck: false, // NATとして機能するために必要
+        userData: userDataScript,
+        rootBlockDevice: {
+            volumeType: "gp3",
+            volumeSize: 8,
+            encrypted: true,
+            deleteOnTermination: true,
+        },
+        metadataOptions: {
+            httpTokens: "required", // IMDSv2を強制
+            httpPutResponseHopLimit: 1,
+        },
+        monitoring: true, // 詳細モニタリング有効化
+        tags: {
+            ...commonTags,
+            Name: pulumi.interpolate`${projectName}-nat-instance-${environment}`,
+            Role: "nat-instance",
+            InstanceType: natInstanceType,
+            Architecture: isArmInstance.apply(isArm => isArm ? "arm64" : "x86_64"),
+        },
+    });
+
+    // Elastic IPをNAT Instanceに関連付け
+    const natInstanceEipAssociation = new aws.ec2.EipAssociation("nat-instance-eip-assoc", {
+        instanceId: natInstance.id,
+        allocationId: natInstanceEip.id,
+    });
+
+    // ========================================
+    // ルーティング設定
+    // ========================================
+    // プライベートサブネットAからのルート
+    new aws.ec2.Route("private-route-a", {
+        routeTableId: privateRouteTableAId,
+        destinationCidrBlock: "0.0.0.0/0",
+        instanceId: natInstance.id,
+    }, {
+        dependsOn: [natInstance],
+    });
+
+    // プライベートサブネットBからのルート
+    new aws.ec2.Route("private-route-b", {
+        routeTableId: privateRouteTableBId,
+        destinationCidrBlock: "0.0.0.0/0",
+        instanceId: natInstance.id,
+    }, {
+        dependsOn: [natInstance],
+    });
+
+    // ========================================
+    // CloudWatchアラーム（モニタリング）
+    // ========================================
+    // インスタンス自動復旧設定
+    new aws.cloudwatch.MetricAlarm("nat-instance-recovery", {
+        alarmDescription: "Recover NAT instance when it fails",
+        metricName: "StatusCheckFailed_System",
+        namespace: "AWS/EC2",
+        statistic: "Maximum",
+        period: 60,
+        evaluationPeriods: 2,
+        threshold: 1,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            InstanceId: natInstance.id,
+        },
+        alarmActions: [
+            pulumi.interpolate`arn:aws:automate:${aws.config.region}:ec2:recover`,
+        ],
+        tags: commonTags,
+    });
+
+    // CPU使用率アラーム
+    new aws.cloudwatch.MetricAlarm("nat-instance-cpu", {
+        alarmDescription: "Alert when NAT instance CPU is high",
+        metricName: "CPUUtilization",
+        namespace: "AWS/EC2",
+        statistic: "Average",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 80,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            InstanceId: natInstance.id,
+        },
+        tags: commonTags,
+    });
+
+    // メモリ使用率アラーム（CloudWatchエージェント経由）
+    new aws.cloudwatch.MetricAlarm("nat-instance-memory", {
+        alarmDescription: "Alert when NAT instance memory is high",
+        metricName: "mem_used_percent",
+        namespace: "CWAgent",
+        statistic: "Average",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 80,
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            InstanceId: natInstance.id,
+            ImageId: natAmiId,
+            InstanceType: natInstanceType,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    // ネットワーク接続数アラーム（カスタムメトリクス）
+    new aws.cloudwatch.MetricAlarm("nat-instance-connections", {
+        alarmDescription: "Alert when NAT instance has high connection count",
+        metricName: "ActiveConnections",
+        namespace: "LambdaAPI/NAT",
+        statistic: "Average",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 1000, // Lambda関数の同時実行数に応じて調整
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            InstanceId: natInstance.id,
+            Environment: environment,
+        },
+        treatMissingData: "notBreaching",
+        tags: commonTags,
+    });
+
+    // ネットワークスループットアラーム
+    new aws.cloudwatch.MetricAlarm("nat-instance-network-out", {
+        alarmDescription: "Alert when NAT instance network output is high",
+        metricName: "NetworkOut",
+        namespace: "AWS/EC2",
+        statistic: "Average",
+        period: 300,
+        evaluationPeriods: 2,
+        threshold: 100000000, // 100MB/5min
+        comparisonOperator: "GreaterThanThreshold",
+        dimensions: {
+            InstanceId: natInstance.id,
+        },
+        tags: commonTags,
+    });
+
+    // ========================================
+    // SSMパラメータへの保存
+    // ========================================
+    const paramPrefix = pulumi.interpolate`/${projectName}/${environment}/nat`;
+
+    // NAT Instance IDを保存
+    new aws.ssm.Parameter("nat-instance-id", {
+        name: pulumi.interpolate`${paramPrefix}/instance/id`,
+        type: "String",
+        value: natInstance.id,
+        description: "NAT Instance ID",
+        tags: commonTags,
+    });
+
+    // NAT Instance Public IPを保存
+    new aws.ssm.Parameter("nat-instance-public-ip", {
+        name: pulumi.interpolate`${paramPrefix}/instance/public-ip`,
+        type: "String",
+        value: natInstanceEip.publicIp,
+        description: "NAT Instance Public IP",
+        tags: commonTags,
+    });
+
+    // NAT Instance Private IPを保存
+    new aws.ssm.Parameter("nat-instance-private-ip", {
+        name: pulumi.interpolate`${paramPrefix}/instance/private-ip`,
+        type: "String",
+        value: natInstance.privateIp,
+        description: "NAT Instance Private IP",
+        tags: commonTags,
+    });
+
+    // NATタイプを保存
+    new aws.ssm.Parameter("nat-type-instance", {
+        name: pulumi.interpolate`${paramPrefix}/type`,
+        type: "String",
+        value: "instance",
+        description: "NAT type (instance)",
+        tags: commonTags,
+    });
+
+    // NAT設定情報を保存
+    new aws.ssm.Parameter("nat-config-instance", {
+        name: pulumi.interpolate`${paramPrefix}/config`,
+        type: "String",
+        value: pulumi.all([natInstanceType, projectName]).apply(([instanceType, proj]) => JSON.stringify({
+            type: "instance",
+            highAvailability: false,
+            instanceType: instanceType,
+            projectName: proj,
+            environment: environment,
+            createdAt: new Date().toISOString(),
+        })),
+        description: "NAT Instance configuration for Lambda API infrastructure",
+        tags: commonTags,
+    });
+
+    // コスト最適化情報のパラメータ
+    new aws.ssm.Parameter("nat-cost-info-instance", {
+        name: `/lambda-api/${environment}/nat/cost-optimization`,
+        type: "String",
+        value: natInstanceType.apply(instanceType => JSON.stringify({
+            estimatedMonthlyCost: `$${instanceType === "t4g.nano" ? "3-5" : instanceType === "t4g.micro" ? "7-10" : "15-20"} (NAT Instance)`,
+            recommendations: [
+                "Monitor data transfer costs using CloudWatch",
+                "Consider VPC endpoints for AWS services to reduce NAT traffic",
+                "Consider NAT Gateway for production for high availability",
+                "Enable detailed billing reports for accurate cost tracking",
+                "Use Reserved Instances or Savings Plans for cost reduction"
+            ],
+            dataTransferThreshold: "< 50GB/month",
+        })),
+        description: "Cost optimization information for NAT Instance configuration",
+        tags: commonTags,
+    });
+
+    // デプロイメント完了フラグ
+    new aws.ssm.Parameter("nat-deployed-instance", {
+        name: pulumi.interpolate`${paramPrefix}/deployment/complete`,
+        type: "String",
+        value: "true",
+        description: "NAT Instance stack deployment completion flag",
+        tags: commonTags,
+    });
+
+    return {
+        natInstanceId: natInstance.id,
+        natInstancePublicIp: natInstanceEip.publicIp,
+        natInstancePrivateIp: natInstance.privateIp,
+        natResourceIds: [natInstance.id],
+    };
+}

--- a/pulumi/lambda-nat/components/nat-instance.ts
+++ b/pulumi/lambda-nat/components/nat-instance.ts
@@ -236,7 +236,7 @@ The script should be located in the 'scripts' directory relative to your project
         userData: userDataScript,
         rootBlockDevice: {
             volumeType: "gp3",
-            volumeSize: 8,
+            volumeSize: 30, // Amazon Linux 2023の最小要件
             encrypted: true,
             deleteOnTermination: true,
         },

--- a/pulumi/lambda-nat/index.ts
+++ b/pulumi/lambda-nat/index.ts
@@ -4,16 +4,12 @@
  * Lambda APIインフラのNATリソースを構築するPulumiスクリプト
  * ハイアベイラビリティモード: NAT Gateway（2つ）
  * ノーマルモード: NAT Instance（1つ）- Amazon Linux 2023 + nftables使用
- * SSMパラメータストアから設定を取得
+ * SSMパラメータストアから設定を取得し、条件に応じて適切なNATリソースを作成
  */
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as fs from "fs";
-import * as path from "path";
-
-// Node.jsグローバル変数の型定義を確実にするため
-declare const __dirname: string;
-declare const process: NodeJS.Process;
+import { createNatGateway, NatGatewayOutputs } from "./components/nat-gateway";
+import { createNatInstance, NatInstanceOutputs } from "./components/nat-instance";
 
 // ========================================
 // 環境変数取得
@@ -67,7 +63,7 @@ const publicSubnetBId = pulumi.output(publicSubnetBIdParam).apply(p => p.value);
 const privateRouteTableAId = pulumi.output(privateRouteTableAIdParam).apply(p => p.value);
 const privateRouteTableBId = pulumi.output(privateRouteTableBIdParam).apply(p => p.value);
 
-// セキュリティ情報を取得
+// セキュリティ情報を取得（NAT Instance用）
 const natInstanceSecurityGroupIdParam = aws.ssm.getParameter({
     name: `/lambda-api/${environment}/security/nat-instance-sg-id`,
 });
@@ -84,432 +80,46 @@ const commonTags = {
 };
 
 // ========================================
-// NATリソース定義
+// NATリソースの条件付き作成
 // ========================================
-// 出力用の変数（条件に応じて後で設定）
-let natResourceIds: pulumi.Output<string>[] = [];
-let natGatewayAId: pulumi.Output<string> | undefined;
-let natGatewayBId: pulumi.Output<string> | undefined;
-let natGatewayEipAAddress: pulumi.Output<string> | undefined;
-let natGatewayEipBAddress: pulumi.Output<string> | undefined;
-let natInstanceId: pulumi.Output<string> | undefined;
-let natInstancePublicIp: pulumi.Output<string> | undefined;
-let natInstancePrivateIp: pulumi.Output<string> | undefined;
-
-// NAT Gateway用リソース（常に作成、HAモードでのみ使用）
-const natGatewayEipA = new aws.ec2.Eip("nat-eip-a", {
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-eip-a-${environment}`,
-        Type: "nat-gateway",
-    },
-});
-
-// NAT Gateway A
-const natGatewayA = new aws.ec2.NatGateway("nat-a", {
-    allocationId: natGatewayEipA.id,
-    subnetId: publicSubnetAId,
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-a-${environment}`,
-    },
-});
-
-// プライベートサブネットAからのルート（後で定義）
-
-// NAT Gateway B用のEIP
-const natGatewayEipB = new aws.ec2.Eip("nat-eip-b", {
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-eip-b-${environment}`,
-        Type: "nat-gateway",
-    },
-});
-
-// NAT Gateway B
-const natGatewayB = new aws.ec2.NatGateway("nat-b", {
-    allocationId: natGatewayEipB.id,
-    subnetId: publicSubnetBId,
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-b-${environment}`,
-    },
-});
-
-// プライベートサブネットBからのルート（後で定義）
-
-natResourceIds = [natGatewayA.id, natGatewayB.id];
-
-// NAT Gateway固有の出力を設定
-natGatewayAId = natGatewayA.id;
-natGatewayBId = natGatewayB.id;
-natGatewayEipAAddress = natGatewayEipA.publicIp;
-natGatewayEipBAddress = natGatewayEipB.publicIp;
-
-// NAT Instance用リソース（常に作成、通常モードでのみ使用）
-
-// Amazon Linux 2023 AMI (ARM64版とx86_64版を自動選択)
-const isArmInstance = natInstanceType.apply(type => 
-    type.startsWith("t4g") || 
-    type.startsWith("m6g") || 
-    type.startsWith("m7g") ||
-    type.startsWith("c6g") ||
-    type.startsWith("c7g")
-);
-    
-// AMIは両方取得して後で選択
-const armAmi = aws.ec2.getAmi({
-    mostRecent: true,
-    owners: ["amazon"],
-    filters: [{
-        name: "name",
-        values: ["al2023-ami-*-kernel-*-arm64"],
-    }],
-});
-
-const x86Ami = aws.ec2.getAmi({
-    mostRecent: true,
-    owners: ["amazon"],
-    filters: [{
-        name: "name",
-        values: ["al2023-ami-*-kernel-*-x86_64"],
-    }],
-});
-
-const natAmiId = isArmInstance.apply(isArm => isArm ? armAmi.then(ami => ami.id) : x86Ami.then(ami => ami.id));
-
-// NAT Instance用のIAMロール
-const natInstanceRole = new aws.iam.Role("nat-instance-role", {
-    assumeRolePolicy: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: [{
-            Action: "sts:AssumeRole",
-            Effect: "Allow",
-            Principal: {
-                Service: "ec2.amazonaws.com",
-            },
-        }],
-    }),
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-instance-role-${environment}`,
-    },
-});
-
-// 必要な権限を付与
-new aws.iam.RolePolicyAttachment("nat-instance-ssm-policy", {
-    role: natInstanceRole.name,
-    policyArn: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-});
-
-new aws.iam.RolePolicyAttachment("nat-instance-cloudwatch-policy", {
-    role: natInstanceRole.name,
-    policyArn: "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
-});
-
-// インスタンスプロファイル
-const natInstanceProfile = new aws.iam.InstanceProfile("nat-instance-profile", {
-    role: natInstanceRole.name,
-    tags: commonTags,
-});
-
-// NAT Instance用のElastic IP
-const natInstanceEip = new aws.ec2.Eip("nat-instance-eip", {
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-instance-eip-${environment}`,
-        Type: "nat-instance",
-    },
-});
-
-    // NAT Instance用のユーザーデータスクリプトを外部ファイルから読み込み
-    // パスを確実に解決
-    const scriptPath = path.resolve(__dirname, '..', '..', 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh');
-    let userDataTemplate: string;
-    
-    try {
-        // ファイルの存在確認
-        if (!fs.existsSync(scriptPath)) {
-            // 別の可能なパスを試す
-            const alternativePath = path.resolve(process.cwd(), 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh');
-            if (fs.existsSync(alternativePath)) {
-                userDataTemplate = fs.readFileSync(alternativePath, 'utf8');
-                pulumi.log.info(`Successfully loaded NAT instance setup script from alternative path: ${alternativePath}`);
-            } else {
-                throw new Error(`Script not found at ${scriptPath} or ${alternativePath}`);
-            }
-        } else {
-            userDataTemplate = fs.readFileSync(scriptPath, 'utf8');
-            pulumi.log.info(`Successfully loaded NAT instance setup script from: ${scriptPath}`);
-        }
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        pulumi.log.error(`Failed to read NAT instance setup script`);
-        pulumi.log.error(`Attempted path: ${scriptPath}`);
-        pulumi.log.error(`Current directory: ${process.cwd()}`);
-        pulumi.log.error(`__dirname: ${__dirname}`);
-        pulumi.log.error(`Error: ${errorMessage}`);
+// 高可用性モードに応じてNATリソースを作成
+// Pulumiの条件付きリソース作成パターンを使用
+highAvailabilityMode.apply(isHA => {
+    if (isHA) {
+        // ========================================
+        // 高可用性モード: NAT Gateway（2つ）
+        // ========================================
+        pulumi.log.info("Creating NAT Gateway resources for high-availability mode");
         
-        // より詳細なヘルプメッセージ
-        pulumi.log.error(`
-Please ensure the NAT instance setup script exists at one of these locations:
-1. ${scriptPath}
-2. ${path.resolve(process.cwd(), 'scripts', 'aws', 'userdata', 'nat-instance-setup.sh')}
-
-The script should be located in the 'scripts' directory relative to your project root.
-        `);
+        createNatGateway({
+            projectName,
+            environment,
+            publicSubnetAId,
+            publicSubnetBId,
+            privateRouteTableAId,
+            privateRouteTableBId,
+            commonTags,
+        });
+    } else {
+        // ========================================
+        // 通常モード: NAT Instance（1つ）
+        // ========================================
+        pulumi.log.info("Creating NAT Instance resources for normal mode");
         
-        throw new Error(`Cannot read NAT instance setup script: ${errorMessage}`);
+        createNatInstance({
+            projectName,
+            environment,
+            vpcCidr,
+            natInstanceType,
+            publicSubnetAId,
+            privateRouteTableAId,
+            privateRouteTableBId,
+            natInstanceSecurityGroupId,
+            commonTags,
+        });
     }
-
-    // テンプレート変数を実際の値に置換
-    const userDataScript = pulumi.all([vpcCidr, projectName]).apply(([cidr, proj]) => {
-        return userDataTemplate
-            .replace(/\${VPC_CIDR}/g, cidr)
-            .replace(/\${PROJECT_NAME}/g, proj)
-            .replace(/\${ENVIRONMENT}/g, environment)
-            .replace(/\${AWS_REGION}/g, aws.config.region || 'ap-northeast-1');
-    });
-
-// NAT Instance
-const natInstance = new aws.ec2.Instance("nat-instance", {
-    ami: natAmiId,
-    instanceType: natInstanceType,
-    // keyName: keyName, // keyNameが必要な場合は別途定義
-    subnetId: publicSubnetAId,
-    vpcSecurityGroupIds: [natInstanceSecurityGroupId],
-    iamInstanceProfile: natInstanceProfile.name,
-    sourceDestCheck: false, // NATとして機能するために必要
-    userData: userDataScript,
-    tags: {
-        ...commonTags,
-        Name: pulumi.interpolate`${projectName}-nat-instance-${environment}`,
-        Role: "nat-instance",
-        InstanceType: natInstanceType,
-        Architecture: isArmInstance ? "arm64" : "x86_64",
-    },
 });
 
-// Elastic IPをNAT Instanceに関連付け
-const natInstanceEipAssociation = new aws.ec2.EipAssociation("nat-instance-eip-assoc", {
-    instanceId: natInstance.id,
-    allocationId: natInstanceEip.id,
-});
-
-// ========================================
-// ルート定義
-// ========================================
-// 現在の環境がHAモードかどうかをSSMから取得した値で判定
-// この場合、動的にルートを作成するのではなく、常に一方を作成
-
-// プライベートサブネットAからのルート - 常にNAT Instanceを使用する簡易版
-// （本来は条件分岐が必要だが、TypeScriptの制約のため簡略化）
-const privateRouteA = new aws.ec2.Route("private-route-a", {
-    routeTableId: privateRouteTableAId,
-    destinationCidrBlock: "0.0.0.0/0",
-    instanceId: natInstance.id, // 簡略化のため、常にNAT Instanceを使用
-});
-
-// プライベートサブネットBからのルート
-const privateRouteB = new aws.ec2.Route("private-route-b", {
-    routeTableId: privateRouteTableBId,
-    destinationCidrBlock: "0.0.0.0/0",
-    instanceId: natInstance.id, // 簡略化のため、常にNAT Instanceを使用
-});
-
-// ========================================
-// モニタリング設定
-// ========================================
-// NAT Instanceの自動復旧設定
-const natInstanceRecoveryAlarm = new aws.cloudwatch.MetricAlarm("nat-instance-recovery", {
-    alarmDescription: "Recover NAT instance when it fails",
-    metricName: "StatusCheckFailed_System",
-    namespace: "AWS/EC2",
-    statistic: "Maximum",
-    period: 60,
-    evaluationPeriods: 2,
-    threshold: 1,
-    comparisonOperator: "GreaterThanThreshold",
-    dimensions: {
-        InstanceId: natInstance.id,
-    },
-    alarmActions: [
-        pulumi.interpolate`arn:aws:automate:${aws.config.region}:ec2:recover`,
-    ],
-    tags: commonTags,
-});
-
-// CPU使用率アラーム
-const natInstanceCpuAlarm = new aws.cloudwatch.MetricAlarm("nat-instance-cpu", {
-    alarmDescription: "Alert when NAT instance CPU is high",
-    metricName: "CPUUtilization",
-    namespace: "AWS/EC2",
-    statistic: "Average",
-    period: 300,
-    evaluationPeriods: 2,
-    threshold: 80,
-    comparisonOperator: "GreaterThanThreshold",
-    dimensions: {
-        InstanceId: natInstance.id,
-    },
-    tags: commonTags,
-});
-
-// Lambda API用カスタムメトリクスアラーム（接続数）
-const natInstanceConnectionsAlarm = new aws.cloudwatch.MetricAlarm("nat-instance-connections", {
-    alarmDescription: "Alert when NAT instance has high connection count",
-    metricName: "ActiveConnections",
-    namespace: "LambdaAPI/NAT",
-    statistic: "Average",
-    period: 300,
-    evaluationPeriods: 2,
-    threshold: 1000, // Lambda関数の同時実行数に応じて調整
-    comparisonOperator: "GreaterThanThreshold",
-    dimensions: {
-        InstanceId: natInstance.id,
-        Environment: environment,
-    },
-    treatMissingData: "notBreaching",
-    tags: commonTags,
-});
-
-natResourceIds = [natInstance.id];
-
-// NAT Instance固有の出力を設定
-natInstanceId = natInstance.id;
-natInstancePublicIp = natInstanceEip.publicIp;
-natInstancePrivateIp = natInstance.privateIp;
-
-// ========================================
-// SSMパラメータへの保存
-// ========================================
-// 他のスタックが参照する値をSSMに保存
-const paramPrefix = pulumi.interpolate`/${projectName}/${environment}/nat`;
-
-// NATタイプを保存
-const natTypeParam = new aws.ssm.Parameter("nat-type", {
-    name: pulumi.interpolate`${paramPrefix}/type`,
-    type: "String",
-    value: highAvailabilityMode.apply(ha => ha ? "gateway-ha" : "instance"),
-    description: "NAT type (gateway-ha or instance)",
-    tags: commonTags,
-});
-
-// NAT Gateway IDを保存（HAモードの場合）
-if (natGatewayAId) {
-    const natGatewayAIdParam = new aws.ssm.Parameter("nat-gateway-a-id", {
-        name: pulumi.interpolate`${paramPrefix}/gateway/a-id`,
-        type: "String",
-        value: natGatewayAId,
-        description: "NAT Gateway A ID",
-        tags: commonTags,
-    });
-}
-if (natGatewayBId) {
-    const natGatewayBIdParam = new aws.ssm.Parameter("nat-gateway-b-id", {
-        name: pulumi.interpolate`${paramPrefix}/gateway/b-id`,
-        type: "String",
-        value: natGatewayBId,
-        description: "NAT Gateway B ID",
-        tags: commonTags,
-    });
-}
-if (natGatewayEipAAddress) {
-    const natGatewayEipAParam = new aws.ssm.Parameter("nat-gateway-eip-a", {
-        name: pulumi.interpolate`${paramPrefix}/gateway/eip-a`,
-        type: "String",
-        value: natGatewayEipAAddress,
-        description: "NAT Gateway A Elastic IP",
-        tags: commonTags,
-    });
-}
-if (natGatewayEipBAddress) {
-    const natGatewayEipBParam = new aws.ssm.Parameter("nat-gateway-eip-b", {
-        name: pulumi.interpolate`${paramPrefix}/gateway/eip-b`,
-        type: "String",
-        value: natGatewayEipBAddress,
-        description: "NAT Gateway B Elastic IP",
-        tags: commonTags,
-    });
-}
-
-// NAT Instance IDを保存（ノーマルモードの場合）
-if (natInstanceId) {
-    const natInstanceIdParam = new aws.ssm.Parameter("nat-instance-id", {
-        name: pulumi.interpolate`${paramPrefix}/instance/id`,
-        type: "String",
-        value: natInstanceId,
-        description: "NAT Instance ID",
-        tags: commonTags,
-    });
-}
-if (natInstancePublicIp) {
-    const natInstancePublicIpParam = new aws.ssm.Parameter("nat-instance-public-ip", {
-        name: pulumi.interpolate`${paramPrefix}/instance/public-ip`,
-        type: "String",
-        value: natInstancePublicIp,
-        description: "NAT Instance Public IP",
-        tags: commonTags,
-    });
-}
-if (natInstancePrivateIp) {
-    const natInstancePrivateIpParam = new aws.ssm.Parameter("nat-instance-private-ip", {
-        name: pulumi.interpolate`${paramPrefix}/instance/private-ip`,
-        type: "String",
-        value: natInstancePrivateIp,
-        description: "NAT Instance Private IP",
-        tags: commonTags,
-    });
-}
-
-// デプロイメント完了フラグ
-const deploymentCompleteParam = new aws.ssm.Parameter("nat-deployed", {
-    name: pulumi.interpolate`${paramPrefix}/deployment/complete`,
-    type: "String",
-    value: "true",
-    description: "NAT stack deployment completion flag",
-    tags: commonTags,
-});
-
-// NAT設定情報を保存
-const natConfigParameter = new aws.ssm.Parameter("nat-config", {
-    name: pulumi.interpolate`${paramPrefix}/config`,
-    type: "String",
-    value: pulumi.all([highAvailabilityMode, natInstanceType, projectName]).apply(
-        ([haMode, instanceType, proj]) => JSON.stringify({
-            type: haMode ? "gateway-ha" : "instance",
-            highAvailability: haMode,
-            instanceType: instanceType,
-            projectName: proj,
-            environment: environment,
-            createdAt: new Date().toISOString(),
-        })
-    ),
-    description: "NAT configuration for Lambda API infrastructure",
-    tags: commonTags,
-});
-
-// コスト最適化情報のパラメータ
-const costOptimizationParameter = new aws.ssm.Parameter("nat-cost-info", {
-    name: `/lambda-api/${environment}/nat/cost-optimization`,
-    type: "String",
-    value: pulumi.all([highAvailabilityMode, natInstanceType]).apply(([haMode, instanceType]) => 
-        JSON.stringify({
-            estimatedMonthlyCost: haMode 
-                ? "$90 (NAT Gateway x2)" 
-                : `$${instanceType === "t4g.nano" ? "3-5" : instanceType === "t4g.micro" ? "7-10" : "15-20"} (NAT Instance)`,
-            recommendations: [
-                "Monitor data transfer costs using CloudWatch",
-                "Consider VPC endpoints for AWS services to reduce NAT traffic",
-                "Use NAT Instance for dev/staging to reduce costs",
-                "Enable detailed billing reports for accurate cost tracking"
-            ],
-            dataTransferThreshold: haMode ? "> 100GB/month" : "< 50GB/month",
-        })
-    ),
-    description: "Cost optimization information for NAT configuration",
-    tags: commonTags,
-});
 
 // ========================================
 // エクスポート（表示用のみ）
@@ -520,8 +130,16 @@ export const outputs = {
     stack: "lambda-nat",
     environment: environment,
     natType: highAvailabilityMode.apply(ha => ha ? "gateway-ha" : "instance"),
-    natInstanceId: natInstanceId,
-    natInstancePublicIp: natInstancePublicIp,
-    ssmParameterPrefix: paramPrefix,
-    deploymentComplete: deploymentCompleteParam.name,
+    ssmParameterPrefix: pulumi.interpolate`/${projectName}/${environment}/nat`,
 };
+
+// デバッグ情報をログに出力
+pulumi.log.info("NAT configuration deployment starting...");
+highAvailabilityMode.apply(isHA => {
+    pulumi.log.info(`Mode: ${isHA ? "High Availability (NAT Gateway)" : "Normal (NAT Instance)"}`);
+    if (!isHA) {
+        natInstanceType.apply(type => {
+            pulumi.log.info(`NAT Instance Type: ${type}`);
+        });
+    }
+});


### PR DESCRIPTION
- NATリソースをコンポーネントに分離（nat-gateway.ts、nat-instance.ts）
- high-availability設定に基づく条件分岐を修正
- 不要なリソース作成を防止
- SSMパラメータ保存処理を各コンポーネント内に移動
- エクスポートを簡素化（条件付きエクスポートを削除）

問題:
- NAT GatewayとNAT Instanceが同時に作成されていた
- ルーティングが常にNAT Instanceを使用していた
- コードの保守性が低下していた

解決:
- モードに応じて必要なリソースのみ作成
- 各モードのロジックを独立したコンポーネントに分離
- TypeScriptの型安全性を活用