### PR TITLE
[pulumi] refactor: Jenkins Agent userdataスクリプトを外部ファイルに切り出し

### DIFF
--- a/scripts/aws/userdata/jenkins-agent-custom-ami.sh
+++ b/scripts/aws/userdata/jenkins-agent-custom-ami.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+set -x
+
+${IPV6_CONFIG}# スワップの有効化（既に作成済み）
+swapon /swapfile || true
+
+# Dockerの起動と権限設定
+systemctl start docker
+chmod 666 /var/run/docker.sock || true
+usermod -aG docker jenkins || true
+
+# 環境情報の保存
+echo "PROJECT_NAME=${PROJECT_NAME}" > /etc/jenkins-agent-env
+echo "ENVIRONMENT=${ENVIRONMENT}" >> /etc/jenkins-agent-env
+echo "AGENT_ROOT=/home/jenkins/agent" >> /etc/jenkins-agent-env
+${ARCHITECTURE_ENV}${IPV6_ENV}chmod 644 /etc/jenkins-agent-env
+
+# SSMエージェントの起動
+systemctl start amazon-ssm-agent
+
+# 起動完了のマーク
+echo "$(date) - Agent bootstrap completed (custom AMI)" > /home/jenkins/agent/bootstrap-complete
+chown jenkins:jenkins /home/jenkins/agent/bootstrap-complete

--- a/scripts/aws/userdata/jenkins-agent-setup.sh
+++ b/scripts/aws/userdata/jenkins-agent-setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Jenkins Agent Bootstrap Script
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+set -x
+
+# スワップファイルの作成（2GB）
+dd if=/dev/zero of=/swapfile bs=1M count=2048
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
+# /tmpの容量を確保（tmpfsのサイズを調整）
+mount -o remount,size=2G /tmp
+
+# システムのアップデートと必要なパッケージのインストール（Javaを除く）
+dnf update -y
+dnf install -y docker git jq amazon-ssm-agent
+
+# 不要なパッケージキャッシュをクリーンアップ
+dnf clean all
+
+# Dockerの設定と起動
+systemctl enable docker
+systemctl start docker
+
+# Dockerソケットの権限設定
+chmod 666 /var/run/docker.sock || true
+
+# Jenkinsユーザーの作成
+useradd -m -d /home/jenkins -s /bin/bash jenkins
+usermod -aG docker jenkins
+
+# エージェント作業ディレクトリの設定
+mkdir -p /home/jenkins/agent
+chown -R jenkins:jenkins /home/jenkins
+
+# 環境情報の保存
+echo "PROJECT_NAME=${PROJECT_NAME}" > /etc/jenkins-agent-env
+echo "ENVIRONMENT=${ENVIRONMENT}" >> /etc/jenkins-agent-env
+echo "AGENT_ROOT=/home/jenkins/agent" >> /etc/jenkins-agent-env
+${ARCHITECTURE_ENV}chmod 644 /etc/jenkins-agent-env
+
+# SSMエージェントの起動
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+
+# Javaのインストール（最後に実行）
+echo "Installing Java..."
+dnf install -y java-21-amazon-corretto
+
+# 起動完了のマーク
+echo "$(date) - Agent bootstrap completed" > /home/jenkins/agent/bootstrap-complete
+chown jenkins:jenkins /home/jenkins/agent/bootstrap-complete


### PR DESCRIPTION
- デフォルトAMI用とカスタムAMI用のuserdataスクリプトを個別のファイルに分離
- jenkins-natの実装パターンに従ってfs.readFileSyncを使用
- テンプレート変数による動的な値の注入をサポート

Fixes #163