### PR TITLE
[jenkins] refactor: 複雑なシェルスクリプトを外部ファイルに分離

### DIFF
--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
@@ -702,212 +702,45 @@ def executePulumiAction(action) {
  * プレビューの実行
  */
 def executePreview() {
-    sh '''#!/bin/bash
-        echo "変更内容のプレビュー..."
+    // スクリプトをコピーして実行
+    sh """
+        # スクリプトをJenkinsリポジトリからコピー
+        cp ${JENKINS_REPO_DIR}/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/*.sh .
+        chmod +x *.sh
         
-        # 空の認証情報環境変数をクリア（IAMロール使用のため）
-        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" = "" ]; then
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            unset AWS_SESSION_TOKEN
-            
-            # EC2メタデータサービスの確認
-            echo "EC2メタデータサービスの確認..."
-            
-            # IMDSv2のトークンを取得
-            TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
-            if [ -n "$TOKEN" ]; then
-                echo "IMDSv2トークンを取得しました"
-                
-                # IAMロール名を取得
-                ROLE_NAME=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/ 2>/dev/null)
-                if [ -n "$ROLE_NAME" ]; then
-                    echo "IAMロール: $ROLE_NAME"
-                    
-                    # 認証情報を取得
-                    CREDS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME 2>/dev/null)
-                    if [ -n "$CREDS" ]; then
-                        export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
-                        export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
-                        export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
-                        echo "EC2インスタンスの認証情報を環境変数に設定しました"
-                    fi
-                fi
-            else
-                echo "警告: IMDSトークンの取得に失敗しました"
-            fi
-        else
-            echo "明示的に指定された認証情報を使用"
-        fi
-        
-        # デバッグ: AWS認証の確認
-        echo "=== AWS認証情報の確認 ==="
-        aws sts get-caller-identity || echo "AWS CLI認証失敗"
-        echo "========================="
-        
-        # デバッグ: 環境変数の確認（認証情報の存在確認）
-        echo "=== 環境変数の確認 ==="
-        echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:+設定済み}"
-        echo "AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:+設定済み}"
-        echo "AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:+設定済み}"
-        echo "AWS_REGION: ${AWS_REGION}"
-        echo "AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}"
-        echo "========================="
-        
-        # JSON形式で出力を保存（パイプラインエラーを適切に処理）
-        set +e
-        pulumi preview --diff --save-plan=plan.json --json 2>&1 | tee ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.json
-        # パイプの最初のコマンド（pulumi）の終了コードを取得
-        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
-        set -e
-        
-        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
-            echo "Pulumiプレビューが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
-            # エラーコードを保存して後で処理
-            echo ${PULUMI_EXIT_CODE} > ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-        fi
-        
-        # エラーがあった場合は例外をスロー
-        if [ -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt ]; then
-            EXIT_CODE=$(cat ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt)
-            rm -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-            exit ${EXIT_CODE}
-        fi
-    '''
+        # Pulumi実行スクリプトを呼び出し
+        ./execute-pulumi.sh preview "${WORKSPACE}" "${ARTIFACTS_DIR}"
+    """
 }
 
 /**
  * デプロイの実行（常に--yesを使用）
  */
 def executeDeploy() {
-    sh '''#!/bin/bash
-        echo "リソースのデプロイ..."
+    // スクリプトをコピーして実行
+    sh """
+        # スクリプトをJenkinsリポジトリからコピー
+        cp ${JENKINS_REPO_DIR}/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/*.sh .
+        chmod +x *.sh
         
-        # 空の認証情報環境変数をクリア（IAMロール使用のため）
-        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" = "" ]; then
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            unset AWS_SESSION_TOKEN
-            
-            # EC2メタデータサービスの確認
-            echo "EC2メタデータサービスの確認..."
-            
-            # IMDSv2のトークンを取得
-            TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
-            if [ -n "$TOKEN" ]; then
-                echo "IMDSv2トークンを取得しました"
-                
-                # IAMロール名を取得
-                ROLE_NAME=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/ 2>/dev/null)
-                if [ -n "$ROLE_NAME" ]; then
-                    echo "IAMロール: $ROLE_NAME"
-                    
-                    # 認証情報を取得
-                    CREDS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME 2>/dev/null)
-                    if [ -n "$CREDS" ]; then
-                        export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
-                        export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
-                        export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
-                        echo "EC2インスタンスの認証情報を環境変数に設定しました"
-                    fi
-                fi
-            else
-                echo "警告: IMDSトークンの取得に失敗しました"
-            fi
-        else
-            echo "明示的に指定された認証情報を使用"
-        fi
-        
-        # JSON形式で出力を保存（パイプラインエラーを適切に処理）
-        set +e
-        pulumi up --yes --diff --json 2>&1 | tee ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.json
-        # パイプの最初のコマンド（pulumi）の終了コードを取得
-        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
-        set -e
-        
-        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
-            echo "Pulumiデプロイが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
-            # エラーコードを保存して後で処理
-            echo ${PULUMI_EXIT_CODE} > ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-        fi
-        
-        echo "デプロイ完了後のスタック出力:"
-        pulumi stack output --json > ${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json || echo "{}" > ${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json
-        cat ${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json | jq '.' || true
-        
-        # エラーがあった場合は例外をスロー
-        if [ -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt ]; then
-            EXIT_CODE=$(cat ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt)
-            rm -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-            exit ${EXIT_CODE}
-        fi
-    '''
+        # Pulumi実行スクリプトを呼び出し
+        ./execute-pulumi.sh deploy "${WORKSPACE}" "${ARTIFACTS_DIR}"
+    """
 }
 
 /**
  * 削除の実行（常に--yesを使用）
  */
 def executeDestroy() {
-    sh '''#!/bin/bash
-        echo "リソースの削除..."
+    // スクリプトをコピーして実行
+    sh """
+        # スクリプトをJenkinsリポジトリからコピー
+        cp ${JENKINS_REPO_DIR}/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/*.sh .
+        chmod +x *.sh
         
-        # 空の認証情報環境変数をクリア（IAMロール使用のため）
-        if [ -z "$AWS_ACCESS_KEY_ID" ] || [ "$AWS_ACCESS_KEY_ID" = "" ]; then
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            unset AWS_SESSION_TOKEN
-            
-            # EC2メタデータサービスの確認
-            echo "EC2メタデータサービスの確認..."
-            
-            # IMDSv2のトークンを取得
-            TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
-            if [ -n "$TOKEN" ]; then
-                echo "IMDSv2トークンを取得しました"
-                
-                # IAMロール名を取得
-                ROLE_NAME=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/ 2>/dev/null)
-                if [ -n "$ROLE_NAME" ]; then
-                    echo "IAMロール: $ROLE_NAME"
-                    
-                    # 認証情報を取得
-                    CREDS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME 2>/dev/null)
-                    if [ -n "$CREDS" ]; then
-                        export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
-                        export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
-                        export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
-                        echo "EC2インスタンスの認証情報を環境変数に設定しました"
-                    fi
-                fi
-            else
-                echo "警告: IMDSトークンの取得に失敗しました"
-            fi
-        else
-            echo "明示的に指定された認証情報を使用"
-        fi
-        
-        # JSON形式で出力を保存（パイプラインエラーを適切に処理）
-        set +e
-        pulumi destroy --yes --json 2>&1 | tee ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.json
-        # パイプの最初のコマンド（pulumi）の終了コードを取得
-        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
-        set -e
-        
-        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
-            echo "Pulumi削除が失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
-            # エラーコードを保存して後で処理
-            echo ${PULUMI_EXIT_CODE} > ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-        fi
-        
-        echo "リソースが削除されました"
-        
-        # エラーがあった場合は例外をスロー
-        if [ -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt ]; then
-            EXIT_CODE=$(cat ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt)
-            rm -f ${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-exit-code.txt
-            exit ${EXIT_CODE}
-        fi
-    '''
+        # Pulumi実行スクリプトを呼び出し
+        ./execute-pulumi.sh destroy "${WORKSPACE}" "${ARTIFACTS_DIR}"
+    """
 }
 
 /**

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+# =====================================================
+# Pulumi実行スクリプト
+# =====================================================
+# 説明: Pulumiアクション（preview/deploy/destroy）を実行
+# 使用方法: ./execute-pulumi.sh <action> <workspace> <artifacts_dir>
+# 引数:
+#   $1: action (preview/deploy/destroy)
+#   $2: workspace path
+#   $3: artifacts directory
+# =====================================================
+
+ACTION="${1:-preview}"
+WORKSPACE="${2:-$WORKSPACE}"
+ARTIFACTS_DIR="${3:-$ARTIFACTS_DIR}"
+
+# 引数チェック
+if [ -z "$ACTION" ] || [ -z "$WORKSPACE" ] || [ -z "$ARTIFACTS_DIR" ]; then
+    echo "エラー: 必要な引数が不足しています"
+    echo "使用方法: $0 <action> <workspace> <artifacts_dir>"
+    exit 1
+fi
+
+echo "Pulumiアクション実行: $ACTION"
+
+# 認証情報のセットアップ（sourceで実行して環境変数を引き継ぐ）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/setup-aws-credentials.sh"
+
+# Pulumiコマンドの実行
+case "$ACTION" in
+    preview)
+        echo "変更内容のプレビュー..."
+        set +e
+        pulumi preview --diff --save-plan=plan.json --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.json"
+        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+        
+        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
+            echo "Pulumiプレビューが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
+            exit ${PULUMI_EXIT_CODE}
+        fi
+        ;;
+        
+    deploy)
+        echo "リソースのデプロイ..."
+        set +e
+        pulumi up --yes --diff --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.json"
+        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+        
+        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
+            echo "Pulumiデプロイが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
+            exit ${PULUMI_EXIT_CODE}
+        fi
+        
+        echo "デプロイ完了後のスタック出力:"
+        pulumi stack output --json > "${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json" || echo "{}" > "${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json"
+        cat "${WORKSPACE}/${ARTIFACTS_DIR}/stack-outputs-post-action.json" | jq '.' || true
+        ;;
+        
+    destroy)
+        echo "リソースの削除..."
+        set +e
+        pulumi destroy --yes --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.json"
+        PULUMI_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+        
+        if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
+            echo "Pulumi削除が失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
+            exit ${PULUMI_EXIT_CODE}
+        fi
+        
+        echo "リソースが削除されました"
+        ;;
+        
+    *)
+        echo "エラー: 不明なアクション: $ACTION"
+        exit 1
+        ;;
+esac
+
+echo "Pulumiアクション完了: $ACTION"

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/setup-aws-credentials.sh
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/setup-aws-credentials.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# =====================================================
+# AWS認証情報セットアップスクリプト
+# =====================================================
+# 説明: IAMロール使用時にIMDSv2から認証情報を取得して環境変数に設定
+# 使用方法: source setup-aws-credentials.sh
+# =====================================================
+
+# 既存の認証情報をチェック
+if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ "${AWS_ACCESS_KEY_ID}" != "" ]; then
+    echo "明示的に指定された認証情報を使用"
+    exit 0
+fi
+
+echo "EC2インスタンスのIAMロールから認証情報を取得中..."
+
+# 空の認証情報環境変数をクリア
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN 2>/dev/null || true
+
+# IMDSv2のトークンを取得
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+
+if [ -z "$TOKEN" ]; then
+    echo "警告: IMDSv2トークンの取得に失敗しました"
+    exit 1
+fi
+
+echo "IMDSv2トークンを取得しました"
+
+# IAMロール名を取得
+ROLE_NAME=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/iam/security-credentials/ 2>/dev/null)
+
+if [ -z "$ROLE_NAME" ]; then
+    echo "警告: IAMロールが見つかりません"
+    exit 1
+fi
+
+echo "IAMロール: $ROLE_NAME"
+
+# 認証情報を取得
+CREDS=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME 2>/dev/null)
+
+if [ -z "$CREDS" ]; then
+    echo "警告: 認証情報の取得に失敗しました"
+    exit 1
+fi
+
+# 環境変数にエクスポート
+export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
+export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
+export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
+
+echo "EC2インスタンスの認証情報を環境変数に設定しました"
+
+# 認証確認
+echo "=== AWS認証情報の確認 ==="
+aws sts get-caller-identity || {
+    echo "AWS CLI認証失敗"
+    exit 1
+}
+echo "========================="


### PR DESCRIPTION
- IMDSv2認証情報取得処理をsetup-aws-credentials.shに分離
- Pulumi実行処理をexecute-pulumi.shに分離
- Jenkinsfileから外部スクリプトを呼び出す形に変更
- メンテナンス性と可読性を大幅に改善

Fixes #175