### PR TITLE
[jenkins] feat: Pulumiダッシュボードジョブの定期実行設定 (#180)

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_dashboard_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_dashboard_job.groovy
@@ -76,6 +76,12 @@ pipelineJob(jobPath) {
         }
     }
     
+    // トリガー設定
+    triggers {
+        // 3時間ごとに実行（0時、3時、6時、9時、12時、15時、18時、21時）
+        cron('0 */3 * * *')
+    }
+    
     // パイプライン定義
     definition {
         cpsScm {


### PR DESCRIPTION
- 3時間ごとの定期実行設定を追加（cron: '0 */3 * * *'）
- SSMダッシュボードと同じ頻度でインフラ状態を自動監視
- 0時、3時、6時、9時、12時、15時、18時、21時に実行