### PR TITLE
[jenkins] add: Pulumi refresh アクションの追加とレポート生成機能 (#183)

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_job.groovy
@@ -78,9 +78,10 @@ pulumiProjects.each { repoKey, repoConfig ->
                     choiceParam('ENVIRONMENT', [env], '環境（自動設定） - この値は変更できません。ジョブの配置場所により自動的に決定されます。')
                     
                     // アクション
-                    choiceParam('ACTION', ['preview', 'deploy', 'destroy'], '''実行するアクション - 実行するPulumiアクションを選択してください：
+                    choiceParam('ACTION', ['preview', 'deploy', 'refresh', 'destroy'], '''実行するアクション - 実行するPulumiアクションを選択してください：
                         |* preview: 変更内容の確認のみ（推奨: 初回実行時）
                         |* deploy: リソースの作成・更新
+                        |* refresh: 実インフラとPulumi状態の同期
                         |* destroy: リソースの削除（要注意）'''.stripMargin())
                     
                     // === AWS認証情報 ===

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
                 stage('Collect Pre-Action Stack Info') {
                     when {
                         expression { 
-                            (params.ACTION == 'destroy' || params.ACTION == 'deploy') && params.GENERATE_REPORT 
+                            (params.ACTION == 'destroy' || params.ACTION == 'deploy' || params.ACTION == 'refresh') && params.GENERATE_REPORT 
                         }
                     }
                     steps {
@@ -172,7 +172,7 @@ pipeline {
                 stage('Collect Post-Action Stack Info') {
                     when {
                         expression { 
-                            (params.ACTION == 'destroy' || params.ACTION == 'deploy') && params.GENERATE_REPORT 
+                            (params.ACTION == 'destroy' || params.ACTION == 'deploy' || params.ACTION == 'refresh') && params.GENERATE_REPORT 
                         }
                     }
                     steps {
@@ -187,7 +187,7 @@ pipeline {
                 stage('Process Results') {
                     when {
                         expression { 
-                            params.ACTION == 'deploy' || params.ACTION == 'destroy'
+                            params.ACTION == 'deploy' || params.ACTION == 'destroy' || params.ACTION == 'refresh'
                         }
                     }
                     steps {
@@ -696,6 +696,10 @@ def executePulumiAction(action) {
             executeDeploy()
             break
             
+        case 'refresh':
+            executeRefresh()
+            break
+            
         case 'destroy':
             executeDestroy()
             break
@@ -735,6 +739,17 @@ def executeDestroy() {
     sh """
         # Pulumi実行スクリプトを呼び出し
         ./execute-pulumi.sh destroy "${WORKSPACE}" "${ARTIFACTS_DIR}"
+    """
+}
+
+/**
+ * Refreshの実行（実インフラとPulumi状態の同期）
+ */
+def executeRefresh() {
+    // スクリプトを実行
+    sh """
+        # Pulumi実行スクリプトを呼び出し
+        ./execute-pulumi.sh refresh "${WORKSPACE}" "${ARTIFACTS_DIR}"
     """
 }
 
@@ -862,12 +877,14 @@ def publishArtifacts() {
     archiveArtifacts artifacts: "${ARTIFACTS_DIR}/**/*.json,${ARTIFACTS_DIR}/**/*.dot", allowEmptyArchive: true
     
     // HTMLレポートの公開
-    if ((params.ACTION == 'deploy' || params.ACTION == 'destroy') && 
+    if ((params.ACTION == 'deploy' || params.ACTION == 'destroy' || params.ACTION == 'refresh') && 
         params.GENERATE_REPORT && 
         fileExists("${HTML_DIR}/index.html")) {
         
         def reportTitle = params.ACTION == 'destroy' ? 
             "Pulumi Destruction Report - ${env.PULUMI_STACK_NAME}" : 
+            params.ACTION == 'refresh' ?
+            "Pulumi Refresh Report - ${env.PULUMI_STACK_NAME}" :
             "Pulumi Deployment Report - ${env.PULUMI_STACK_NAME}"
         
         // 高解像度グラフファイルも含める


### PR DESCRIPTION
- DSLファイルのACTIONパラメータにrefreshを追加
- execute-pulumi.shにrefreshアクションの実装を追加
  - refresh前後の状態を保存して差分を可視化
  - pulumi refreshコマンドの実行と結果の保存
- JenkinsfileにexecuteRefresh関数を追加
- レポート生成ステージでrefreshアクションを対象に含める
  - Pre/Post-Action Stack Infoの収集条件にrefreshを追加
  - Process Resultsステージの条件にrefreshを追加
  - HTMLレポート公開条件にrefreshを追加
  - レポートタイトルにRefresh Report形式を追加

実インフラとPulumi状態の同期を単独で実行可能になり、
refresh結果もHTMLレポートとして確認できるようになりました。