### PR TITLE
[jenkins] fix: DSLスクリプトのエスケープ文字を修正

### DIFF
--- a/jenkins/jobs/dsl/admin/admin_test_ec2_fleet_job.groovy
+++ b/jenkins/jobs/dsl/admin/admin_test_ec2_fleet_job.groovy
@@ -78,7 +78,7 @@ job(fullJobName) {
             |fi
             |echo ""
             |echo "■ iノード使用状況:"
-            |df -i | awk 'NR==1 {print "  " $0} /\/$/ {print "  " $0}'
+            |df -i | awk 'NR==1 {print "  " $0} /\\/$/ {print "  " $0}'
             |
             |# ネットワーク情報
             |echo "IPアドレス: $(hostname -I | awk '{print $1}')"


### PR DESCRIPTION
- awkパターン内のスラッシュを適切にエスケープ
- iノード使用状況表示でルートファイルシステムを正しくフィルタリング