### PR TITLE
[jenkins] fix: restore-configジョブの共有ライブラリブランチ参照を修正

### DIFF
--- a/jenkins/jobs/pipeline/admin/restore-config/Jenkinsfile
+++ b/jenkins/jobs/pipeline/admin/restore-config/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('jenkins-shared-lib@fix-2025-08-26') _
+@Library('jenkins-shared-lib') _
 
 pipeline {
     agent { label 'built-in' }


### PR DESCRIPTION
- 存在しないブランチ 'fix-2025-08-26' への参照を削除
- デフォルトブランチを使用するように修正