### PR TITLE
[pulumi] add: Lambda Shipment S3バケットとSSM初期設定を実装 (#210)

### DIFF
--- a/pulumi/lambda-shipment-s3/Pulumi.yaml
+++ b/pulumi/lambda-shipment-s3/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: lambda-shipment-s3
+runtime: nodejs
+description: Common S3 lambda shipment bucket

--- a/pulumi/lambda-shipment-s3/index.ts
+++ b/pulumi/lambda-shipment-s3/index.ts
@@ -1,0 +1,96 @@
+/**
+ * pulumi/lambda-shipment-s3/index.ts
+ * 
+ * Lambda関数デプロイメント用S3バケットを構築するPulumiスクリプト
+ * Lambdaパッケージの保存・バージョニング管理用バケットを作成
+ */
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { LambdaDeploymentBucket } from "@tielec/pulumi-components";
+
+// ========================================
+// 環境変数取得
+// ========================================
+const environment = pulumi.getStack();
+const region = aws.config.region || "ap-northeast-1";
+
+// ========================================
+// SSMパラメータ参照（Single Source of Truth）
+// ========================================
+// プロジェクト名を取得
+const projectNameParam = aws.ssm.getParameter({
+    name: `/lambda-api/${environment}/common/project-name`,
+});
+const projectName = pulumi.output(projectNameParam).apply(p => p.value);
+
+// ========================================
+// 共通設定
+// ========================================
+// 共通タグ定義
+const commonTags = {
+    Environment: environment,
+    ManagedBy: "pulumi",
+    Project: projectName,
+    Stack: pulumi.getProject(),
+    SharedResource: "true",
+};
+
+// ========================================
+// S3バケット作成
+// ========================================
+const bucketName = `tielec-lambda-shipment-${environment}`;
+
+const deploymentBucket = new LambdaDeploymentBucket("lambda-shipment", {
+  useExisting: false,  // 新規作成を明示的に指定
+  bucketName: bucketName,
+  versioning: true,
+  lifecycleDays: 7,
+  tags: commonTags,
+});
+
+// ========================================
+// SSMパラメータへの保存
+// ========================================
+// 他のスタックが参照する値をSSMに保存
+const paramPrefix = pulumi.interpolate`/lambda-shipment/${environment}`;
+
+// バケット名
+const bucketNameParam = new aws.ssm.Parameter("bucket-name", {
+    name: pulumi.interpolate`${paramPrefix}/bucket/name`,
+    type: "String",
+    value: deploymentBucket.bucketName,
+    description: "Lambda Shipment S3 Bucket Name",
+    tags: commonTags,
+});
+
+// バケットARN
+const bucketArnParam = new aws.ssm.Parameter("bucket-arn", {
+    name: pulumi.interpolate`${paramPrefix}/bucket/arn`,
+    type: "String",
+    value: deploymentBucket.bucketArn,
+    description: "Lambda Shipment S3 Bucket ARN",
+    tags: commonTags,
+});
+
+// リージョン
+const regionParam = new aws.ssm.Parameter("region", {
+    name: pulumi.interpolate`${paramPrefix}/region`,
+    type: "String",
+    value: region,
+    description: "Lambda Shipment Deployment Region",
+    tags: commonTags,
+});
+
+// ========================================
+// エクスポート（表示用のみ）
+// ========================================
+// エクスポートは表示・確認用のみ
+// 他のスタックはSSMパラメータから値を取得すること
+export const outputs = {
+    stack: "lambda-shipment-s3",
+    environment: environment,
+    bucketName: deploymentBucket.bucketName,
+    bucketArn: deploymentBucket.bucketArn,
+    region: region,
+    ssmParameterPrefix: paramPrefix,
+};

--- a/pulumi/lambda-shipment-s3/package.json
+++ b/pulumi/lambda-shipment-s3/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lambda-shipment-s3",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Common S3 lambda shipment bucket",
+  "main": "index.ts",
+  "scripts": {
+    "prepare": "cd ../components && npm install",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/aws": "^6.0.0",
+    "@tielec/pulumi-components": "file:../components"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/pulumi/lambda-shipment-s3/tsconfig.json
+++ b/pulumi/lambda-shipment-s3/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2019",
+    "module": "commonjs",
+    "lib": ["ES2019"],
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pulumi/lambda-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.dev.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: ap-northeast-1
+  lambda-ssm-init:githubToken: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_GITHUB_TOKEN

--- a/pulumi/lambda-ssm-init/Pulumi.prod.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.prod.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: ap-northeast-1
+  lambda-ssm-init:githubToken: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_GITHUB_TOKEN

--- a/pulumi/lambda-ssm-init/index.ts
+++ b/pulumi/lambda-ssm-init/index.ts
@@ -11,7 +11,9 @@ import * as aws from "@pulumi/aws";
 // ========================================
 // 環境変数取得
 // ========================================
+const config = new pulumi.Config();
 const environment = pulumi.getStack();
+const githubToken = config.require("githubToken");
 
 // ========================================
 // 初期設定
@@ -167,6 +169,16 @@ for (const [name, value] of Object.entries(secureParams)) {
     parameters.push(param);
 }
 
+// GitHub Personal Access Token 用のSSM Parameter（Pulumiコンフィグから取得）
+const githubTokenParam = new aws.ssm.Parameter("github-token", {
+    name: `${paramPrefix}/security/github-token`,
+    description: "GitHub Personal Access Token for repository access",
+    type: "SecureString",
+    value: githubToken,
+    tags: commonTags,
+});
+parameters.push(githubTokenParam);
+
 // ========================================
 // スタック依存関係定義
 // ========================================
@@ -215,6 +227,7 @@ export const outputs = {
     ssmParameterPrefix: paramPrefix,
     parametersCreated: parameters.length,
     initCompleteFlag: initComplete.name,
+    githubTokenParameterName: githubTokenParam.name,
 };
 
 // デプロイ完了の確認用


### PR DESCRIPTION
- lambda-shipment-s3: Lambdaパッケージ保存用S3バケットスタック追加
- lambda-ssm-init: GitHub Token管理機能を追加
- CONTRIBUTION.mdガイドラインに準拠した実装

Refs #209