### PR TITLE
[jenkins] add: reflection-cloud-apiリポジトリをjenkins-managed-repositories…

### DIFF
--- a/jenkins/jobs/pipeline/_seed/job-creator/job-config.yaml
+++ b/jenkins/jobs/pipeline/_seed/job-creator/job-config.yaml
@@ -241,6 +241,15 @@ jenkins-managed-repositories:
     technicalDocsStartDate: '2025-01-01'
     technicalDocsFile: REPODOC.md
     updatePullRequestTitle: 'true'
+  
+  reflection-cloud-api:
+    httpsUrl: https://github.com/tielec/reflection-cloud-api
+    mainBranch: main
+    docBranch: document
+    credentialsId: github-app-credentials
+    technicalDocsStartDate: '2025-01-01'
+    technicalDocsFile: REPODOC.md
+    updatePullRequestTitle: 'true'
 
 # Pulumiプロジェクト定義
 pulumi-projects:


### PR DESCRIPTION
…に追加 (#217)

- jenkins-managed-repositoriesセクションにreflection-cloud-apiを追加
- GitHub docs-generatorジョブの対象リポジトリとして設定
- 技術ドキュメント自動生成の対象に含める