### PR TITLE
[jenkins] improve: Pulumi実行ログを人間が読みやすい形式に変更 (#225)

### DIFF
--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
@@ -34,7 +34,7 @@ case "$ACTION" in
     preview)
         echo "変更内容のプレビュー..."
         set +e
-        pulumi preview --diff --save-plan=plan.json --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.json"
+        pulumi preview --diff --save-plan=plan.json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.log"
         PULUMI_EXIT_CODE=${PIPESTATUS[0]}
         set -e
         
@@ -47,7 +47,7 @@ case "$ACTION" in
     deploy)
         echo "リソースのデプロイ..."
         set +e
-        pulumi up --yes --diff --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.json"
+        pulumi up --yes --diff 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.log"
         PULUMI_EXIT_CODE=${PIPESTATUS[0]}
         set -e
         
@@ -69,7 +69,7 @@ case "$ACTION" in
         pulumi stack export --file "${WORKSPACE}/${ARTIFACTS_DIR}/stack-state-before-refresh.json" 2>/dev/null || true
         
         set +e
-        pulumi refresh --yes --diff --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-refresh.json"
+        pulumi refresh --yes --diff 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-refresh.log"
         PULUMI_EXIT_CODE=${PIPESTATUS[0]}
         set -e
         
@@ -90,7 +90,7 @@ case "$ACTION" in
     destroy)
         echo "リソースの削除..."
         set +e
-        pulumi destroy --yes --json 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.json"
+        pulumi destroy --yes 2>&1 | tee "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.log"
         PULUMI_EXIT_CODE=${PIPESTATUS[0]}
         set -e
         


### PR DESCRIPTION
- JSON形式のログ出力を廃止し、通常の読みやすい形式に変更
- 出力ファイル名を .json から .log に変更（用途の明確化）
- Jenkinsコンソールでのリアルタイム確認が容易に
- デバッグ・トラブルシューティングの効率向上

改善内容:
- preview: pulumi-preview.json → pulumi-preview.log
- deploy: pulumi-up.json → pulumi-up.log
- refresh: pulumi-refresh.json → pulumi-refresh.log
- destroy: pulumi-destroy.json → pulumi-destroy.log