### PR TITLE
[pulumi] update: Jenkins SpotFleetエージェントのEBS最適化を有効化 (#242)

### DIFF
--- a/jenkins/jobs/pipeline/admin/github-webhooks-setting/Jenkinsfile
+++ b/jenkins/jobs/pipeline/admin/github-webhooks-setting/Jenkinsfile
@@ -26,12 +26,18 @@ pipeline {
                     // リポジトリ名の正規化（ハイフンを除去、小文字に変換）
                     env.REPO_NAME_NORMALIZED = env.REPO_NAME.replaceAll('-', '').toLowerCase()
                     
+                    // JENKINS_BASE_URLの末尾のスラッシュを取り除く
+                    def jenkinsBaseUrl = params.JENKINS_BASE_URL
+                    if (jenkinsBaseUrl.endsWith('/')) {
+                        jenkinsBaseUrl = jenkinsBaseUrl.substring(0, jenkinsBaseUrl.length() - 1)
+                    }
+                    
                     // Webhook URLの構築
                     if (params.CUSTOM_WEBHOOK_URL) {
                         env.WEBHOOK_URL = params.CUSTOM_WEBHOOK_URL
                         echo "カスタムWebhook URLを使用します"
                     } else {
-                        env.WEBHOOK_URL = "${params.JENKINS_BASE_URL}/generic-webhook-trigger/invoke?token=${env.REPO_NAME_NORMALIZED}-${params.WEBHOOK_TOKEN_SUFFIX}"
+                        env.WEBHOOK_URL = "${jenkinsBaseUrl}/generic-webhook-trigger/invoke?token=${env.REPO_NAME_NORMALIZED}-${params.WEBHOOK_TOKEN_SUFFIX}"
                     }
                     
                     echo "Repository: ${env.REPO_OWNER}/${env.REPO_NAME}"

--- a/pulumi/jenkins-agent/index.ts
+++ b/pulumi/jenkins-agent/index.ts
@@ -234,6 +234,7 @@ const agentLaunchTemplate = new aws.ec2.LaunchTemplate(`agent-lt`, {
     imageId: amiX86Id,
     instanceType: "t3a.medium", // デフォルトをt3a.mediumに変更（AMDプロセッサで10%安価）
     keyName: agentKeyPair.keyName,  // 作成したキーペアを使用
+    ebsOptimized: "true",  // EBS最適化を有効化
     // vpcSecurityGroupIds は networkInterfaces と競合するため削除
     iamInstanceProfile: {
         name: jenkinsAgentProfile.name,
@@ -333,6 +334,7 @@ const agentLaunchTemplateArm = new aws.ec2.LaunchTemplate(`agent-lt-arm`, {
     imageId: amiArmId,
     instanceType: "t4g.medium",
     keyName: agentKeyPair.keyName,
+    ebsOptimized: "true",  // EBS最適化を有効化
     // vpcSecurityGroupIds は networkInterfaces と競合するため削除
     iamInstanceProfile: {
         name: jenkinsAgentProfile.name,


### PR DESCRIPTION
- x86_64用とARM64用の両方の起動テンプレートでebsOptimizedをtrueに設定
- EC2インスタンスとEBSボリューム間の専用帯域幅を確保
- ビルド時のディスクI/Oパフォーマンスが向上
- t3a.medium, t3.medium, t4g.mediumは追加料金なしでEBS最適化が利用可能