### PR TITLE
[pulumi] fix: S3バケット名にアカウント番号とリージョンを追加して一意性を確保

### DIFF
--- a/pulumi/jenkins-ssm-backup-s3/index.ts
+++ b/pulumi/jenkins-ssm-backup-s3/index.ts
@@ -6,8 +6,12 @@ const config = new pulumi.Config();
 const projectName = config.require("projectName");
 const environment = config.require("environment");
 
-// S3バケット名の生成
-const bucketName = `${projectName}-ssm-backup-${environment}`;
+// AWSアカウント情報とリージョンを取得
+const accountId = aws.getCallerIdentity().then(identity => identity.accountId);
+const region = aws.config.region || "ap-northeast-1";
+
+// S3バケット名の生成（アカウント番号とリージョンを含めて一意性を確保）
+const bucketName = pulumi.interpolate`${projectName}-ssm-backup-${environment}-${accountId}-${region}`;
 
 // SSMパラメータバックアップ用S3バケット
 const backupBucket = new aws.s3.Bucket("ssm-backup-bucket", {

--- a/pulumi/lambda-shipment-s3/index.ts
+++ b/pulumi/lambda-shipment-s3/index.ts
@@ -14,6 +14,9 @@ import { LambdaDeploymentBucket } from "@tielec/pulumi-components";
 const environment = pulumi.getStack();
 const region = aws.config.region || "ap-northeast-1";
 
+// AWSアカウント情報を取得
+const accountId = aws.getCallerIdentity().then(identity => identity.accountId);
+
 // ========================================
 // SSMパラメータ参照（Single Source of Truth）
 // ========================================
@@ -25,7 +28,8 @@ const projectNameParam = aws.ssm.getParameter({
 // ========================================
 // S3バケット作成
 // ========================================
-const bucketName = `tielec-lambda-shipment-${environment}`;
+// アカウント番号とリージョンを含めて一意性を確保
+const bucketName = pulumi.interpolate`tielec-lambda-shipment-${environment}-${accountId}-${region}`;
 
 // プロジェクト名を解決してからバケットを作成
 const deploymentBucket = pulumi.output(projectNameParam).apply(param => {


### PR DESCRIPTION
- jenkins-ssm-backup-s3: アカウント番号とリージョンをsuffixに追加
- lambda-shipment-s3: アカウント番号とリージョンをsuffixに追加
- S3バケット名のグローバル一意性制約に対応