### PR TITLE
[pulumi] remove: Lambda関数のVPC設定を削除

### DIFF
--- a/pulumi/lambda-functions/components/lambda-factory.ts
+++ b/pulumi/lambda-functions/components/lambda-factory.ts
@@ -26,8 +26,8 @@ export function createLambdaFunction(
         s3Bucket: pulumi.Output<string>;
         s3Key: pulumi.Output<string>;
         dlqArn: pulumi.Output<string>;
-        vpcSubnetIds: pulumi.Output<string[]>;
-        vpcSecurityGroupIds: pulumi.Output<string>[];
+        vpcSubnetIds?: pulumi.Output<string[]>;
+        vpcSecurityGroupIds?: pulumi.Output<string>[];
         
         // オプションパラメータ
         description?: string;
@@ -70,11 +70,11 @@ export function createLambdaFunction(
             variables: config.environmentVariables || {},
         },
         
-        // VPC設定
-        vpcConfig: {
+        // VPC設定（オプショナル）
+        vpcConfig: config.vpcSubnetIds && config.vpcSecurityGroupIds ? {
             subnetIds: config.vpcSubnetIds,
             securityGroupIds: config.vpcSecurityGroupIds,
-        },
+        } : undefined,
         
         // DLQ設定
         deadLetterConfig: {


### PR DESCRIPTION
- VPC関連のSSMパラメータ取得処理を削除
- Lambda関数作成時のVPC設定パラメータを削除
- IAMロールからVPCアクセス権限（AWSLambdaVPCAccessExecutionRole）を削除
- lambda-factory.tsでVPC設定をオプショナルに変更

現在の運用環境ではVPCなしの構成が適しているため、Lambda関数を
よりシンプルな構成に変更。

Fixes #264