### PR TITLE
[jenkins] fix: pulumi-dashboardのスタック詳細をプロジェクト名順にソート

### DIFF
--- a/jenkins/jobs/pipeline/infrastructure/pulumi-dashboard/src/dashboard_generator.py
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-dashboard/src/dashboard_generator.py
@@ -273,9 +273,9 @@ def main():
     
     # データを読み込み
     data = load_data(args.data_dir)
-    
-    # デフォルトのソート（最終更新日時の降順）
-    data = sort_data(data, 'last_updated', 'desc')
+
+    # デフォルトのソート（プロジェクト名順）
+    data = sort_data(data, 'project_name', 'asc')
     
     # タイムスタンプの設定
     timestamp = args.timestamp or datetime.now().strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
レポート生成時のデフォルトソート順を変更:
- 変更前: 最終更新日時の降順
- 変更後: プロジェクト名の昇順

これにより同じプロジェクトのスタックがまとまって表示され、
レポートの視認性が向上

Fixes #268