### PR TITLE
[ansible] refactor: jenkins_configのSSMドキュメント名取得を統合

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -85,19 +85,3 @@ lambda_api_infra:
   # AWS設定
   aws:
     default_region: "ap-northeast-1"
-
-# ============================================================
-# Jenkins プロジェクト設定
-# ============================================================
-
-# Jenkins設定
-jenkins:
-  version: "latest"
-  color: "blue"
-  recovery_mode: false
-
-  # Git設定
-  git:
-    repo: "https://github.com/tielec/infrastructure-as-code.git"
-    branch: "main"
-

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_application.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_application.yml
@@ -15,7 +15,6 @@
     # コマンドラインから環境名を受け取る
     env_name: "{{ env | default('dev') }}"
     # アプリケーション設定
-    jenkins_version: "{{ version | default('latest') }}"
     restart_jenkins: "{{ restart | default(true) }}"
     install_plugins: "{{ plugins | default(true) }}"
     update_repo: "{{ update_git | default(true) }}"
@@ -34,9 +33,6 @@
         controller_project_name: "{{ infra.pulumi.controller_project }}"
         config_project_name: "{{ infra.pulumi.config_project }}"
         application_project_name: "{{ infra.pulumi.application_project | default('jenkins-application') }}"
-        git_repo: "{{ git_repo | default(jenkins.git.repo) }}"
-        git_branch: "{{ git_branch | default(jenkins.git.branch) }}"
-        jenkins_color: "{{ color | default(jenkins.color) }}"
   
   roles:
     - jenkins_application

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_config.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_config.yml
@@ -33,11 +33,6 @@
         loadbalancer_project_name: "{{ infra.pulumi.loadbalancer_project }}"
         controller_project_name: "{{ infra.pulumi.controller_project }}"
         config_project_name: "{{ infra.pulumi.config_project }}"
-        jenkins_version: "{{ version | default(jenkins.version) }}"
-        jenkins_color: "{{ color | default(jenkins.color) }}"
-        recovery_mode: "{{ recovery | default(jenkins.recovery_mode) }}"
-        git_repo: "{{ git_repo | default(jenkins.git.repo) }}"
-        git_branch: "{{ git_branch | default(jenkins.git.branch) }}"
 
   roles:
     - jenkins_config

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_controller.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_controller.yml
@@ -31,9 +31,6 @@
         storage_project_name: "{{ infra.pulumi.storage_project }}"
         loadbalancer_project_name: "{{ infra.pulumi.loadbalancer_project }}"
         controller_project_name: "{{ infra.pulumi.controller_project }}"
-        jenkins_version: "{{ version | default(jenkins.version) }}"
-        jenkins_color: "{{ color | default(jenkins.color) }}"
-        recovery_mode: "{{ recovery | default(jenkins.recovery_mode) }}"
   
   roles:
     - jenkins_controller

--- a/ansible/roles/jenkins_application/tasks/deploy.yml
+++ b/ansible/roles/jenkins_application/tasks/deploy.yml
@@ -13,23 +13,59 @@
   register: aws_env_script_permission
   no_log: true
 
-# SSMドキュメント名の取得（jenkins-configで作成されたものを使用）
-- name: Get execute script document name from SSM Parameter Store
-  ansible.builtin.include_role:
-    name: ssm_parameter_store
-    tasks_from: get_parameter
-  vars:
-    parameter_name: "/jenkins-infra/{{ env_name }}/config/execute-script-document-name"
-    store_as: "execute_script_document_name"
+# SSMパラメータストアから必要な設定を一括取得
+- name: Retrieve all required parameters from SSM Parameter Store
+  block:
+    # Git設定パラメータの取得
+    - name: Get Git repository from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/git-repo"
+        store_as: "git_repo"
+      when: git_repo is not defined
 
-# jenkins_configのSSMドキュメントも取得（SSMパラメータから）
-- name: Get config update repo document name from SSM Parameter Store
-  ansible.builtin.include_role:
-    name: ssm_parameter_store
-    tasks_from: get_parameter
-  vars:
-    parameter_name: "/jenkins-infra/{{ env_name }}/config/update-repo-document-name"
-    store_as: "config_update_repo_document_name"
+    - name: Get Git branch from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/git-branch"
+        store_as: "git_branch"
+      when: git_branch is not defined
+
+    # SSMドキュメント名の取得
+    - name: Get execute script document name from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/config/execute-script-document-name"
+        store_as: "execute_script_document_name"
+
+    - name: Get config update repo document name from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/config/update-repo-document-name"
+        store_as: "config_update_repo_document_name"
+
+    # JenkinsインスタンスIDの取得
+    - name: Get Jenkins instance ID from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/controller/instance-id"
+        store_as: "jenkins_instance_id"
+
+# パラメータの検証
+- name: Verify Jenkins instance ID format
+  ansible.builtin.fail:
+    msg: "Invalid Jenkins instance ID format: {{ jenkins_instance_id }}"
+  when: not (jenkins_instance_id | regex_search('^i-[a-f0-9]+$'))
 
 # Pulumiデプロイ（アプリケーションステータスパラメータのみを作成）
 - name: Deploy Application Status Parameters with Pulumi
@@ -70,23 +106,6 @@
       ansible.builtin.fail:
         msg: "Jenkins application deployment failed."
 
-# Jenkinsインスタンスの取得（Parameter Storeから）
-- name: Get active Jenkins instance
-  block:
-    - name: Get Jenkins instance ID from SSM Parameter Store
-      ansible.builtin.include_role:
-        name: ssm_parameter_store
-        tasks_from: get_parameter
-      vars:
-        parameter_name: "/jenkins-infra/{{ env_name }}/controller/instance-id"
-        store_as: "jenkins_instance_id"
-    
-    - name: Verify Jenkins instance ID
-      ansible.builtin.fail:
-        msg: "Invalid Jenkins instance ID format: {{ jenkins_instance_id }}"
-      when: not (jenkins_instance_id | regex_search('^i-[a-f0-9]+$'))
-    
-
 # アプリケーション設定の実行
 - name: Execute application configuration tasks
   block:
@@ -105,7 +124,7 @@
     
     # 2. Jenkinsバージョン更新（プラグインインストール前に実行）
     - name: Update Jenkins version if required
-      when: jenkins_version != 'latest' or update_jenkins | default(false) | bool
+      when: update_jenkins | default(false) | bool
       block:
         - name: Execute Jenkins version update
           ansible.builtin.include_tasks: execute_ssm_command.yml

--- a/ansible/roles/jenkins_config/tasks/setup.yml
+++ b/ansible/roles/jenkins_config/tasks/setup.yml
@@ -5,29 +5,96 @@
   ansible.builtin.debug:
     msg: "Configuring Jenkins Controller for {{ env_name }} environment"
 
-# JenkinsインスタンスIDの取得（Parameter Storeから）
-- name: Get Jenkins instance ID from SSM Parameter Store
-  ansible.builtin.include_role:
-    name: ssm_parameter_store
-    tasks_from: get_parameter
-  vars:
-    parameter_name: "/jenkins-infra/{{ env_name }}/controller/instance-id"
-    store_as: "jenkins_instance_id"
+# SSMパラメータストアから必要な設定を一括取得
+- name: Retrieve all required parameters from SSM Parameter Store
+  block:
+    # Jenkins設定パラメータの取得
+    - name: Get Jenkins version from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/jenkins-version"
+        store_as: "jenkins_version"
+      when: jenkins_version is not defined
 
-- name: Verify Jenkins instance ID
+    - name: Get Jenkins color from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/jenkins-color"
+        store_as: "jenkins_color"
+      when: jenkins_color is not defined
+
+    - name: Get Jenkins recovery mode from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/jenkins-recovery-mode"
+        store_as: "recovery_mode"
+      when: recovery_mode is not defined
+
+    # Git設定パラメータの取得
+    - name: Get Git repository from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/git-repo"
+        store_as: "git_repo"
+      when: git_repo is not defined
+
+    - name: Get Git branch from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/{{ project_name }}/{{ env_name }}/config/git-branch"
+        store_as: "git_branch"
+      when: git_branch is not defined
+
+    # インフラストラクチャIDの取得
+    - name: Get Jenkins instance ID from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/controller/instance-id"
+        store_as: "jenkins_instance_id"
+
+    - name: Get EFS file system ID from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/storage/efs-file-system-id"
+        store_as: "efs_file_system_id"
+      when: efs_file_system_id is not defined or efs_file_system_id == ""
+
+    # SSMドキュメント名の取得
+    - name: Get update repo document name from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/config/update-repo-document-name"
+        store_as: "update_repo_document_name"
+
+    - name: Get execute script document name from SSM
+      ansible.builtin.include_role:
+        name: ssm_parameter_store
+        tasks_from: get_parameter
+      vars:
+        parameter_name: "/jenkins-infra/{{ env_name }}/config/execute-script-document-name"
+        store_as: "execute_script_document_name"
+
+# パラメータの検証
+- name: Verify Jenkins instance ID format
   ansible.builtin.fail:
     msg: "Invalid Jenkins instance ID format: {{ jenkins_instance_id }}"
   when: not (jenkins_instance_id | regex_search('^i-[a-f0-9]+$'))
-
-# EFSファイルシステムIDの取得 - SSM Parameter Storeから優先的に取得
-- name: Get EFS file system ID from Parameter Store
-  when: efs_file_system_id is not defined or efs_file_system_id == ""
-  ansible.builtin.include_role:
-    name: ssm_parameter_store
-    tasks_from: get_parameter
-  vars:
-    parameter_name: "/jenkins-infra/{{ env_name }}/storage/efs-file-system-id"
-    store_as: "efs_file_system_id"
 
 # ファイル権限設定
 - name: Ensure aws-env.sh has execute permissions
@@ -74,23 +141,6 @@
         tasks_from: deploy
       vars:
         pulumi_project_path: "{{ pulumi_path }}/jenkins-config"
-    
-    # SSMドキュメント名の取得（SSMパラメータから）
-    - name: Get update repo document name from SSM Parameter Store
-      ansible.builtin.include_role:
-        name: ssm_parameter_store
-        tasks_from: get_parameter
-      vars:
-        parameter_name: "/jenkins-infra/{{ env_name }}/config/update-repo-document-name"
-        store_as: "update_repo_document_name"
-    
-    - name: Get execute script document name from SSM Parameter Store
-      ansible.builtin.include_role:
-        name: ssm_parameter_store
-        tasks_from: get_parameter
-      vars:
-        parameter_name: "/jenkins-infra/{{ env_name }}/config/execute-script-document-name"
-        store_as: "execute_script_document_name"
     
   
   rescue:


### PR DESCRIPTION
- Pulumiデプロイブロック内にあったSSMドキュメント名取得を最初のSSM取得ブロックに移動
- すべてのSSMパラメータ取得を1箇所に集約して可読性向上