### PR TITLE
[ansible] refactor: 不要なPulumiバックエンド設定パラメータを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,6 @@ AWS_REGION                 # AWSリージョン（デフォルト: ap-northeast-
 ### オプション
 ```bash
 JENKINS_VERSION           # Jenkinsバージョン
-PULUMI_STATE_BUCKET_NAME  # S3バケット名（自動検出可能）
 DEPLOY_ENV               # デプロイ環境（dev/staging/prod）
 ```
 

--- a/README.md
+++ b/README.md
@@ -271,11 +271,7 @@ export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter \
   --query 'Parameter.Value' \
   --output text)
 
-# S3バケット名を設定（オプション - 通常は自動検出）
-export PULUMI_STATE_BUCKET_NAME=$(aws cloudformation describe-stacks \
-  --stack-name bootstrap-environment \
-  --query "Stacks[0].Outputs[?OutputKey=='PulumiStateBucketName'].OutputValue" \
-  --output text)
+# S3バケット名はSSMパラメータストアから自動取得されるため、手動設定は不要
 ```
 
 **パスフレーズの優先順位**:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -307,7 +307,6 @@ ansible-playbook playbooks/lambda/lambda_api_gateway.yml -e "env=dev"
 | 変数名 | 説明 | デフォルト値 |
 |--------|------|-------------|
 | `JENKINS_VERSION` | Jenkinsバージョン | 2.426.1 |
-| `PULUMI_STATE_BUCKET_NAME` | Pulumiステート用S3バケット | 自動検出 |
 | `DEPLOY_ENV` | デプロイ環境 | dev |
 | `ANSIBLE_VAULT_PASSWORD_FILE` | Vault パスワードファイル | なし |
 

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -35,15 +35,9 @@ aws_credentials_script_path: "{{ scripts_dir }}/aws/setup-aws-credentials.sh"
 # Pulumi設定
 # ============================================================
 
-pulumi:
-  # バックエンドタイプ（"cloud" または "s3"）
-  backend_type: "s3"
-
-  # S3バックエンド設定
-  s3:
-    # S3バケット名（CloudFormationで作成されたバケット名を指定）
-    bucket: ""  # 空の場合はSSMパラメータストアから取得
-    region: "ap-northeast-1"
+# S3バックエンド固定
+# S3バケット名はSSMパラメータストア(/bootstrap/pulumi/s3bucket-name)から自動取得
+# リージョンはaws_regionパラメータを使用
 
 # ============================================================
 # Jenkins インフラストラクチャ設定

--- a/ansible/roles/pulumi_helper/defaults/main.yml
+++ b/ansible/roles/pulumi_helper/defaults/main.yml
@@ -1,17 +1,10 @@
 # Pulumiヘルパーのデフォルト変数
 pulumi_base_path: "{{ inventory_dir }}/../../pulumi"
 
-# バックエンド設定
-# all.ymlから読み込むか、デフォルト値を使用
-pulumi_backend_type: "{{ pulumi.backend_type | default('s3') }}"
-
-# Pulumi Cloud設定
-pulumi_cloud_url: "{{ pulumi.cloud.url | default('https://api.pulumi.com') }}"
-
-# S3バックエンド設定
-# all.ymlから読み込むか、CloudFormationで作成されたバケットを自動検出
-pulumi_s3_bucket: "{{ pulumi.s3.bucket | default(pulumi_state_bucket_name | default('')) }}"
-pulumi_s3_region: "{{ pulumi.s3.region | default('ap-northeast-1') }}"
+# S3バックエンド設定（S3バックエンド固定）
+# S3バケット名はSSMパラメータストアから自動取得されるため、デフォルトは空
+pulumi_s3_bucket: ""
+pulumi_s3_region: "{{ aws_region }}"
 # S3バックエンドのパスフレーズは環境変数PULUMI_CONFIG_PASSPHRASEから取得
 
 # ログ出力の制御

--- a/ansible/roles/pulumi_helper/meta/main.yml
+++ b/ansible/roles/pulumi_helper/meta/main.yml
@@ -4,5 +4,5 @@ dependencies:
   - role: aws_setup
   - role: ssm_parameter_store
     vars:
-      # S3バックエンド使用時にPULUMI_CONFIG_PASSPHRASEを自動取得
-      ssm_parameter_store_auto_fetch_passphrase: "{{ pulumi_backend_type | default('s3') == 's3' }}"
+      # S3バックエンド固定のためPULUMI_CONFIG_PASSPHRASEを自動取得
+      ssm_parameter_store_auto_fetch_passphrase: true

--- a/ansible/roles/pulumi_helper/tasks/deploy.yml
+++ b/ansible/roles/pulumi_helper/tasks/deploy.yml
@@ -30,7 +30,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Deploy with Pulumi
   block:

--- a/ansible/roles/pulumi_helper/tasks/destroy.yml
+++ b/ansible/roles/pulumi_helper/tasks/destroy.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Destroy Pulumi stack
   block:

--- a/ansible/roles/pulumi_helper/tasks/get_outputs.yml
+++ b/ansible/roles/pulumi_helper/tasks/get_outputs.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Get stack outputs
   block:

--- a/ansible/roles/pulumi_helper/tasks/init_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/init_stack.yml
@@ -5,10 +5,9 @@
   ansible.builtin.include_tasks: login.yml
   when: pulumi_authenticated is not defined
 
-# S3バックエンドの場合、プロジェクト別ログイン
+# S3バックエンドのプロジェクト別ログイン（S3バックエンド固定）
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Initialize and set up Pulumi stack
   block:
@@ -19,9 +18,7 @@
           Initializing Pulumi stack:
           Project: {{ pulumi_project_path | basename }}
           Stack: {{ stack_name }}
-          {% if pulumi_backend_type == 's3' %}
           Backend: {{ pulumi_s3_backend_url }}
-          {% endif %}
     
     - name: Verify project directory exists
       ansible.builtin.stat:
@@ -58,13 +55,8 @@
       ansible.builtin.shell: |
         cd {{ pulumi_project_path }}
         {{ pulumi_env_prefix }}
-        {% if pulumi_backend_type == 's3' %}
         # S3バックエンドではシンプルなスタック名を使用
         {{ pulumi_sudo_cmd }} stack init {{ stack_name }} --secrets-provider=passphrase
-        {% else %}
-        # Pulumi Cloudでは解決済みの完全な名前を使用
-        {{ pulumi_sudo_cmd }} stack init {{ resolved_stack_name }}
-        {% endif %}
       register: stack_init_result
       changed_when: stack_init_result.rc == 0
       when: 

--- a/ansible/roles/pulumi_helper/tasks/login.yml
+++ b/ansible/roles/pulumi_helper/tasks/login.yml
@@ -9,93 +9,37 @@
         pulumi_bin_path: "/usr/local/bin/pulumi"
       when: pulumi_bin_path is not defined
 
-    # バックエンドタイプの検証
-    - name: Validate backend type
-      ansible.builtin.fail:
-        msg: "Invalid pulumi_backend_type: {{ pulumi_backend_type }}. Must be 'cloud' or 's3'"
-      when: pulumi_backend_type not in ['cloud', 's3']
-
-    # Pulumi Cloud認証の処理
-    - name: Handle Pulumi Cloud authentication
-      when: pulumi_backend_type == 'cloud'
+    # S3バックエンド認証の処理（S3バックエンド固定）
+    - name: Handle S3 backend authentication
       block:
-        # PULUMI_ACCESS_TOKENの確認
-        - name: Check for PULUMI_ACCESS_TOKEN in environment
-          ansible.builtin.set_fact:
-            pulumi_token_set: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') | length > 0 }}"
-            pulumi_access_token: "{{ lookup('env', 'PULUMI_ACCESS_TOKEN') }}"
-          no_log: true
+        # S3バケット名をSSMから取得
+        - name: Retrieve S3 bucket name from SSM Parameter Store
+          ansible.builtin.include_role:
+            name: ssm_parameter_store
+            tasks_from: get_parameter
+          vars:
+            parameter_name: "/bootstrap/pulumi/s3bucket-name"
+            decrypt: false
+            store_as: "pulumi_s3_bucket_from_ssm"
+            ssm_parameter_store_fail_on_missing: false
+            default_value: ""
 
-        - name: Fail if PULUMI_ACCESS_TOKEN is not set
+        - name: Set S3 bucket name from SSM
+          ansible.builtin.set_fact:
+            pulumi_s3_bucket: "{{ pulumi_s3_bucket_from_ssm }}"
+          when: pulumi_s3_bucket_from_ssm | length > 0
+
+        - name: Fail if S3 bucket name cannot be determined
           ansible.builtin.fail:
             msg: |
-              ERROR: PULUMI_ACCESS_TOKEN environment variable is not set.
-              Please set the PULUMI_ACCESS_TOKEN environment variable before running this playbook:
-              export PULUMI_ACCESS_TOKEN="pul-YOUR_ACCESS_TOKEN"
-          when: not pulumi_token_set
+              ERROR: S3 bucket name is not configured in SSM Parameter Store.
 
-        # ログイン状態の確認
-        - name: Check current Pulumi Cloud login status
-          ansible.builtin.shell: |
-            export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
-            sudo -E {{ pulumi_bin_path }} whoami
-          register: pulumi_login_check
-          changed_when: false
-          failed_when: false
-          no_log: true
+              Please run the bootstrap setup to create the S3 bucket:
+              1. cd bootstrap/
+              2. ./setup-bootstrap.sh
 
-        # ログインが必要な場合のみログイン実行
-        - name: Login to Pulumi Cloud if not already logged in
-          ansible.builtin.shell: |
-            export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
-            sudo -E {{ pulumi_bin_path }} login --cloud-url {{ pulumi_cloud_url }}
-          when: pulumi_login_check.rc != 0
-          register: pulumi_login_result
-          changed_when: pulumi_login_result.rc == 0
-          no_log: true
-
-        # 環境変数をエクスポートする共通コマンドを定義
-        - name: Set Pulumi Cloud environment prefix
-          ansible.builtin.set_fact:
-            pulumi_env_prefix: >-
-              export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}";
-              source {{ inventory_dir }}/../../scripts/aws/aws-env.sh > /dev/null &&
-              eval $({{ inventory_dir }}/../../scripts/aws/aws-env.sh) > /dev/null
-
-    # S3バックエンド認証の処理
-    - name: Handle S3 backend authentication
-      when: pulumi_backend_type == 's3'
-      block:
-        # S3バケット名が空の場合はSSMから取得
-        - name: Get S3 bucket name from SSM if not set
+              Or ensure the parameter exists in SSM: /bootstrap/pulumi/s3bucket-name
           when: pulumi_s3_bucket is not defined or pulumi_s3_bucket | length == 0
-          block:
-            - name: Retrieve S3 bucket name from SSM Parameter Store
-              ansible.builtin.include_role:
-                name: ssm_parameter_store
-                tasks_from: get_parameter
-              vars:
-                parameter_name: "/bootstrap/pulumi/s3bucket-name"
-                decrypt: false
-                store_as: "pulumi_s3_bucket_from_ssm"
-                ssm_parameter_store_fail_on_missing: false
-                default_value: ""
-
-            - name: Set S3 bucket name from SSM
-              ansible.builtin.set_fact:
-                pulumi_s3_bucket: "{{ pulumi_s3_bucket_from_ssm }}"
-              when: pulumi_s3_bucket_from_ssm | length > 0
-
-            - name: Fail if S3 bucket name cannot be determined
-              ansible.builtin.fail:
-                msg: |
-                  ERROR: S3 bucket name is not configured.
-                  
-                  Please either:
-                  1. Set it in ansible/inventory/group_vars/all.yml under pulumi.s3.bucket
-                  2. Or ensure it exists in SSM parameter: /bootstrap/pulumi/s3bucket-name
-                  3. Or run the bootstrap setup to create the S3 bucket
-              when: pulumi_s3_bucket is not defined or pulumi_s3_bucket | length == 0
 
         # まず環境変数をチェック
         - name: Check for PULUMI_CONFIG_PASSPHRASE in environment
@@ -155,10 +99,10 @@
                 export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter --name "/bootstrap/pulumi/config-passphrase" --with-decryption --query 'Parameter.Value' --output text)
           when: not pulumi_passphrase_set
 
-        # 環境変数をエクスポートする共通コマンドを定義（S3用）
+        # 環境変数をエクスポートする共通コマンドを定義
         # 注: S3バックエンドのURLはプロジェクトごとに異なるため、
         # 実際のログインは各タスクで行う（init_stack.yml等で処理）
-        - name: Set S3 backend environment prefix
+        - name: Set environment prefix
           ansible.builtin.set_fact:
             pulumi_env_prefix: >-
               export PULUMI_CONFIG_PASSPHRASE="{{ pulumi_config_passphrase }}";
@@ -171,45 +115,27 @@
     - name: Set common Pulumi settings
       block:
         # sudoを使用したPulumiコマンドのプレフィックス
-        # S3バックエンドの場合はsudoを使わない
+        # S3バックエンドではsudoを使わない
         - name: Set Pulumi sudo command prefix
           ansible.builtin.set_fact:
-            pulumi_sudo_cmd: "{{ pulumi_bin_path if pulumi_backend_type == 's3' else 'sudo -E ' + pulumi_bin_path }}"
+            pulumi_sudo_cmd: "{{ pulumi_bin_path }}"
 
-        # Pulumi Cloudの場合のみログイン検証
-        - name: Verify Pulumi Cloud login successful
-          when: pulumi_backend_type == 'cloud'
-          ansible.builtin.shell: |
-            export PULUMI_ACCESS_TOKEN="{{ pulumi_access_token }}"
-            {{ pulumi_sudo_cmd }} whoami
-          register: pulumi_verify_login
-          changed_when: false
-          failed_when: pulumi_verify_login.rc != 0
-          no_log: true
-
-        # verbosity > 1 の場合のみログイン状態を表示
-        - name: Display Pulumi login status
+        # verbosity > 1 の場合のみ設定状態を表示
+        - name: Display Pulumi configuration status
           ansible.builtin.debug:
             msg: |
-              Pulumi backend type: {{ pulumi_backend_type }}
-              {% if pulumi_backend_type == 'cloud' %}
-              Authenticated as: {{ pulumi_verify_login.stdout }}
-              {% else %}
               S3 backend configured (login will be performed per project)
               S3 bucket: {{ pulumi_s3_bucket }}
               Region: {{ pulumi_s3_region }}
-              {% endif %}
           when: ansible_verbosity > 1
 
-        # S3バケット名のソースを表示（S3バックエンドの場合）
+        # S3バケット名のソースを表示
         - name: Display S3 bucket source (debug mode)
           ansible.builtin.debug:
             msg: |
               S3 bucket name: {{ pulumi_s3_bucket }}
-              Source: {{ 'SSM Parameter Store' if pulumi_s3_bucket_from_ssm is defined else 'all.yml configuration' }}
-          when: 
-            - pulumi_backend_type == 's3'
-            - ansible_verbosity > 1
+              Source: SSM Parameter Store (/bootstrap/pulumi/s3bucket-name)
+          when: ansible_verbosity > 1
 
         # 認証完了フラグを設定（重複チェックを防ぐため）
         - name: Mark authentication as complete
@@ -220,20 +146,13 @@
     - name: Handle authentication failure
       ansible.builtin.fail:
         msg: |
-          Failed to authenticate to Pulumi {{ pulumi_backend_type }} backend.
-          {% if pulumi_backend_type == 'cloud' %}
-          Please ensure:
-          1. PULUMI_ACCESS_TOKEN is correctly set
-          2. The token is valid and not expired
-          3. You have internet connectivity to reach Pulumi service
-          {% else %}
+          Failed to authenticate to Pulumi S3 backend.
           Please ensure:
           1. PULUMI_CONFIG_PASSPHRASE is correctly set
           2. AWS credentials are properly configured
           3. S3 bucket '{{ pulumi_s3_bucket }}' exists and is accessible
           4. AWS region is set to '{{ pulumi_s3_region }}'
-          {% endif %}
-          
+
           Error details: {{ ansible_failed_result.msg | default('Unknown error') }}
 
 # チェックモード用の処理
@@ -242,22 +161,16 @@
   block:
     - name: Set mock values for check mode
       ansible.builtin.set_fact:
-        pulumi_token_set: true
-        pulumi_access_token: "mock-token-for-check-mode"
         pulumi_config_passphrase: "mock-passphrase-for-check-mode"
         pulumi_env_prefix: >-
-          {% if pulumi_backend_type == 'cloud' %}
-          export PULUMI_ACCESS_TOKEN='mock-token-for-check-mode'
-          {% else %}
           export PULUMI_CONFIG_PASSPHRASE='mock-passphrase-for-check-mode';
           export AWS_REGION='{{ pulumi_s3_region }}';
           export AWS_DEFAULT_REGION='{{ pulumi_s3_region }}'
-          {% endif %}
         pulumi_sudo_cmd: "pulumi"
         pulumi_bin_path: "/usr/local/bin/pulumi"
         pulumi_authenticated: true
 
     - name: Display check mode notice
       ansible.builtin.debug:
-        msg: "Running in check mode - Pulumi {{ pulumi_backend_type }} authentication will be mocked"
+        msg: "Running in check mode - Pulumi S3 authentication will be mocked"
       when: ansible_verbosity > 1

--- a/ansible/roles/pulumi_helper/tasks/preview.yml
+++ b/ansible/roles/pulumi_helper/tasks/preview.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Preview Pulumi deployment
   block:

--- a/ansible/roles/pulumi_helper/tasks/refresh.yml
+++ b/ansible/roles/pulumi_helper/tasks/refresh.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Refresh Pulumi stack
   block:

--- a/ansible/roles/pulumi_helper/tasks/remove_stack.yml
+++ b/ansible/roles/pulumi_helper/tasks/remove_stack.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Remove Pulumi stack
   block:

--- a/ansible/roles/pulumi_helper/tasks/resolve_stack_name.yml
+++ b/ansible/roles/pulumi_helper/tasks/resolve_stack_name.yml
@@ -7,10 +7,9 @@
   ansible.builtin.include_tasks: login.yml
   when: pulumi_authenticated is not defined
 
-# S3バックエンドの場合、プロジェクト別ログイン
+# S3バックエンドのプロジェクト別ログイン（S3バックエンド固定）
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 # verbosity > 2 の場合のみ詳細を表示
 - name: Display resolution start
@@ -18,54 +17,15 @@
     msg: "Resolving stack name: {{ stack_name }}"
   when: ansible_verbosity > 2
 
-# S3バックエンドの場合はシンプルなスタック名を使用
-- name: Handle S3 backend stack name
-  when: pulumi_backend_type == 's3'
-  block:
-    - name: Set simple stack name for S3 backend
-      ansible.builtin.set_fact:
-        resolved_stack_name: "{{ stack_name }}"
-    
-    - name: Display S3 backend stack resolution
-      ansible.builtin.debug:
-        msg: "S3 backend uses simple stack names without organization"
-      when: ansible_verbosity > 1
+# S3バックエンドのシンプルなスタック名を使用（S3バックエンド固定）
+- name: Set simple stack name for S3 backend
+  ansible.builtin.set_fact:
+    resolved_stack_name: "{{ stack_name }}"
 
-# Pulumi Cloudの場合は組織名を含む完全な名前を使用
-- name: Handle Pulumi Cloud stack name
-  when: pulumi_backend_type == 'cloud'
-  block:
-    - name: Read Pulumi.yaml configuration
-      ansible.builtin.slurp:
-        src: "{{ pulumi_project_path }}/Pulumi.yaml"
-      register: pulumi_yaml_content
-      when: not ansible_check_mode
-
-    - name: Parse Pulumi configuration
-      ansible.builtin.set_fact:
-        pulumi_config: "{{ pulumi_yaml_content.content | b64decode | from_yaml }}"
-      when: not ansible_check_mode
-
-    # デバッグ情報はverbosity > 2の場合のみ
-    - name: Display parsed configuration
-      ansible.builtin.debug:
-        msg: |
-          Pulumi.yaml contents:
-          - Name: {{ pulumi_config.name | default('not set') }}
-          - Organization: {{ pulumi_config.organization | default('not set') }}
-      when: 
-        - not ansible_check_mode
-        - ansible_verbosity > 2
-
-    - name: Set resolved stack name for Pulumi Cloud
-      ansible.builtin.set_fact:
-        resolved_stack_name: >-
-          {%- if pulumi_config.organization is defined and pulumi_config.organization -%}
-            {{ pulumi_config.organization }}/{{ pulumi_config.name }}/{{ stack_name }}
-          {%- else -%}
-            {{ stack_name }}
-          {%- endif -%}
-      when: not ansible_check_mode
+- name: Display S3 backend stack resolution
+  ansible.builtin.debug:
+    msg: "S3 backend uses simple stack names without organization"
+  when: ansible_verbosity > 1
 
 # チェックモード用
 - name: Set mock resolved stack name (check mode)
@@ -78,5 +38,5 @@
   ansible.builtin.debug:
     msg: |
       Resolved stack name: {{ resolved_stack_name }}
-      Backend type: {{ pulumi_backend_type }}
+      Backend type: S3
   when: ansible_verbosity > 1

--- a/ansible/roles/pulumi_helper/tasks/s3_backend_login.yml
+++ b/ansible/roles/pulumi_helper/tasks/s3_backend_login.yml
@@ -4,9 +4,7 @@
 # 各タスクからincludeして使用する共通処理
 
 - name: Login to S3 backend for current project
-  when: 
-    - pulumi_backend_type == 's3'
-    - pulumi_project_path is defined
+  when: pulumi_project_path is defined
   block:
     # プロジェクト名を取得（未定義の場合）
     - name: Get project name if not already set

--- a/ansible/roles/pulumi_helper/tasks/set_config.yml
+++ b/ansible/roles/pulumi_helper/tasks/set_config.yml
@@ -8,7 +8,6 @@
 # S3バックエンドの場合、プロジェクト別ログイン
 - name: Handle S3 backend project login
   ansible.builtin.include_tasks: s3_backend_login.yml
-  when: pulumi_backend_type == 's3'
 
 - name: Configure Pulumi stack
   block:


### PR DESCRIPTION
- pulumi.s3.bucket: SSMから自動取得するため削除
- pulumi_state_bucket_name: 未使用の変数を削除
- pulumi.s3.region: aws_regionパラメータを直接参照
- pulumi.backend_type: S3バックエンド固定のため削除
- Pulumi Cloud関連のコードをすべて削除

これらの変更により、設定が簡素化され、重複が解消されました。
S3バケット名はSSMパラメータストア(/bootstrap/pulumi/s3bucket-name)から 自動取得され、リージョンはaws_regionパラメータを使用します。