### PR TITLE
[ansible] refactor: プロジェクト名設定を階層構造に変更

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -40,17 +40,11 @@ aws_credentials_script_path: "{{ scripts_dir }}/aws/setup-aws-credentials.sh"
 # リージョンはaws_regionパラメータを使用
 
 # ============================================================
-# Jenkins インフラストラクチャ設定
+# プロジェクト設定
 # ============================================================
 
-infra:
-  # プロジェクト名
-  project_name: "jenkins-infra"
-
-# ============================================================
-# Lambda API インフラストラクチャ設定
-# ============================================================
-
-lambda_api_infra:
-  # プロジェクト名
-  project_name: "lambda-api"
+projects:
+  jenkins:
+    name: "jenkins-infra"
+  lambda_api:
+    name: "lambda-api"

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent.yml
@@ -23,7 +23,7 @@
     # 必要な変数を設定 - ロールに渡す変数の準備
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_agent

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent_ami.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_agent_ami.yml
@@ -23,7 +23,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Display deployment information
       ansible.builtin.debug:

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_application.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_application.yml
@@ -28,7 +28,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_application

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_config.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_config.yml
@@ -25,7 +25,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
 
   roles:
     - jenkins_config

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_controller.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_controller.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_controller

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_loadbalancer.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_loadbalancer.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_loadbalancer

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_nat.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_nat.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_nat

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_network.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_network.yml
@@ -23,7 +23,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_network

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_security.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_security.yml
@@ -23,7 +23,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_security

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_ssm_init.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_ssm_init.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - aws_setup

--- a/ansible/playbooks/jenkins/deploy/deploy_jenkins_storage.yml
+++ b/ansible/playbooks/jenkins/deploy/deploy_jenkins_storage.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
   
   roles:
     - jenkins_storage

--- a/ansible/playbooks/jenkins/maintenance/cleanup_image_builder_amis.yml
+++ b/ansible/playbooks/jenkins/maintenance/cleanup_image_builder_amis.yml
@@ -41,7 +41,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
         cleanup_dry_run: "{{ dry_run | default(true) }}"
         cleanup_retention_count: "{{ retention_count | default(1) }}"
     

--- a/ansible/playbooks/jenkins/misc/update_jenkins_ami_ssm.yml
+++ b/ansible/playbooks/jenkins/misc/update_jenkins_ami_ssm.yml
@@ -25,7 +25,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
         env: "{{ env_name }}"
     
     - name: Get Pipeline ARNs from SSM

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_agent.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_agent.yml
@@ -30,7 +30,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_agent_ami.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_agent_ami.yml
@@ -30,7 +30,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_application.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_application.yml
@@ -28,7 +28,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_config.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_config.yml
@@ -28,7 +28,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_controller.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_controller.yml
@@ -30,7 +30,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_loadbalancer.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_loadbalancer.yml
@@ -28,7 +28,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_nat.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_nat.yml
@@ -28,7 +28,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
 
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_network.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_network.yml
@@ -31,7 +31,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_security.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_security.yml
@@ -30,7 +30,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_ssm_init.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_ssm_init.yml
@@ -24,7 +24,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     # 削除確認
     - name: Confirm SSM parameter deletion

--- a/ansible/playbooks/jenkins/remove/remove_jenkins_storage.yml
+++ b/ansible/playbooks/jenkins/remove/remove_jenkins_storage.yml
@@ -33,7 +33,7 @@
     # 必要な変数を設定
     - name: Set required variables from all.yml
       ansible.builtin.set_fact:
-        project_name: "{{ infra.project_name }}"
+        project_name: "{{ projects.jenkins.name }}"
     
     - name: Check confirmation flag
       ansible.builtin.fail:

--- a/ansible/playbooks/lambda/lambda_api_gateway.yml
+++ b/ansible/playbooks/lambda/lambda_api_gateway.yml
@@ -22,7 +22,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_functions.yml
+++ b/ansible/playbooks/lambda/lambda_functions.yml
@@ -22,7 +22,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_nat.yml
+++ b/ansible/playbooks/lambda/lambda_nat.yml
@@ -22,7 +22,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_network.yml
+++ b/ansible/playbooks/lambda/lambda_network.yml
@@ -22,7 +22,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_security.yml
+++ b/ansible/playbooks/lambda/lambda_security.yml
@@ -22,7 +22,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_ssm_init.yml
+++ b/ansible/playbooks/lambda/lambda_ssm_init.yml
@@ -23,7 +23,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:

--- a/ansible/playbooks/lambda/lambda_vpce.yml
+++ b/ansible/playbooks/lambda/lambda_vpce.yml
@@ -23,7 +23,7 @@
     
     - name: Set required variables
       ansible.builtin.set_fact:
-        project_name: "{{ lambda_api_infra.project_name }}"
+        project_name: "{{ projects.lambda_api.name }}"
         
     - name: Display operation info
       ansible.builtin.debug:


### PR DESCRIPTION
all.ymlの設定構造を改善：
- infra.project_name → projects.jenkins.name
- lambda_api_infra.project_name → projects.lambda_api.name

これにより設定がより整理され、プロジェクトごとに拡張しやすい構造になりました。