### PR TITLE
[jenkins] fix: Ansibleジョブの環境パラメータを固定値に変更

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_ansible_playbook_executor_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_ansible_playbook_executor_job.groovy
@@ -89,11 +89,11 @@ ${playbookListText}
 **リポジトリ**: ${repoKey}""")
             
             parameters {
-                // 環境選択
-                choiceParam('ENVIRONMENT', ['dev', 'staging', 'prod'], '実行環境')
+                // 環境選択（固定値：このジョブの環境のみ）
+                choiceParam('ENVIRONMENT', [env], '実行環境')
                 
                 // AWSリージョン
-                choiceParam('AWS_REGION', ['ap-northeast-1', 'us-west-2'], 'AWSリージョン')
+                choiceParam('AWS_REGION', ['us-west-2', 'ap-northeast-1'], 'AWSリージョン')
                 
                 // ブランチ選択
                 stringParam('BRANCH', 'main', 'リポジトリブランチ（デフォルト: main）')


### PR DESCRIPTION
- 各環境ごとのジョブでENVIRONMENTパラメータをその環境のみに固定
- AWS_REGIONのデフォルトをus-west-2に変更