### PR TITLE
[pulumi][jenkins] update: OpenAIモデルをgpt-4.1とgpt-4.1-miniに更新

### DIFF
--- a/jenkins/jobs/pipeline/code-quality-checker/pr-complexity-analyzer/src/pr_complexity_comment_generator.py
+++ b/jenkins/jobs/pipeline/code-quality-checker/pr-complexity-analyzer/src/pr_complexity_comment_generator.py
@@ -63,7 +63,7 @@ class ComplexityStatistics:
 class OpenAIConfig:
     """OpenAI API設定"""
     api_key: str
-    model: str = "gpt-4o"
+    model: str = "gpt-4.1"
     temperature: float = 0.7
     max_tokens: int = 3000
     debug_mode: bool = False
@@ -234,7 +234,7 @@ class PRComplexityCommentGenerator:
         # OpenAI設定を構築
         self.config = OpenAIConfig(
             api_key=os.getenv("OPENAI_API_KEY"),
-            model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+            model=os.getenv("OPENAI_MODEL", "gpt-4.1"),
             debug_mode=debug_mode
         )
         

--- a/jenkins/jobs/pipeline/docs-generator/auto-insert-doxygen-comment/src/common/openai_client.py
+++ b/jenkins/jobs/pipeline/docs-generator/auto-insert-doxygen-comment/src/common/openai_client.py
@@ -17,7 +17,7 @@ class OpenAIClient:
             api_key=api_key
         )
         self.model_name = model_name or "gpt-4.1"
-        self.fallback_model_name = "gpt-4o"  # フォールバック用のモデル
+        self.fallback_model_name = "gpt-4.1"  # フォールバック用のモデル
         self.usage_stats = {
             'prompt_tokens': 0,
             'completion_tokens': 0

--- a/jenkins/jobs/pipeline/docs-generator/technical-docs-writer/src/api/openai_client.py
+++ b/jenkins/jobs/pipeline/docs-generator/technical-docs-writer/src/api/openai_client.py
@@ -37,7 +37,7 @@ class OpenAIClient:
             api_key=api_key
         )
         self.model_name = model_name or "gpt-4.1"
-        self.fallback_model_name = "gpt-4o"  # フォールバック用のモデル
+        self.fallback_model_name = "gpt-4.1"  # フォールバック用のモデル
         self.usage_stats = {'prompt_tokens': 0, 'completion_tokens': 0}
         self.save_reflection = save_reflection
         self.template_manager = template_manager  # template_manager をインスタンス変数として保存

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -321,8 +321,8 @@ Lambda API環境では、Claude APIとOpenAI APIを利用するための設定�
 
 **OpenAI API設定:**
 - `/lambda-api/{env}/app/settings/openai-api-key` - APIキー（SecureString）
-- `/lambda-api/{env}/app/settings/openai-speed-model` - 高速処理用モデル（デフォルト: gpt-4-turbo）
-- `/lambda-api/{env}/app/settings/openai-quality-model` - 高品質処理用モデル（デフォルト: gpt-4o）
+- `/lambda-api/{env}/app/settings/openai-speed-model` - 高速処理用モデル（デフォルト: gpt-4.1-mini）
+- `/lambda-api/{env}/app/settings/openai-quality-model` - 高品質処理用モデル（デフォルト: gpt-4.1）
 
 ```bash
 # AI APIキーの設定（初回デプロイ後、AWSコンソールで実際のキーに更新）

--- a/pulumi/lambda-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.dev.yaml
@@ -28,5 +28,5 @@ config:
   lambda-ssm-init:claudeQualityModel: "claude-3-5-sonnet-20240620"
   # AI API設定（OpenAI API）
   lambda-ssm-init:openaiApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
-  lambda-ssm-init:openaiSpeedModel: "gpt-4-turbo"
-  lambda-ssm-init:openaiQualityModel: "gpt-4o"
+  lambda-ssm-init:openaiSpeedModel: "gpt-4.1-mini"
+  lambda-ssm-init:openaiQualityModel: "gpt-4.1"

--- a/pulumi/lambda-ssm-init/Pulumi.prod.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.prod.yaml
@@ -28,5 +28,5 @@ config:
   lambda-ssm-init:claudeQualityModel: "claude-3-5-sonnet-20240620"
   # AI API設定（OpenAI API）
   lambda-ssm-init:openaiApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
-  lambda-ssm-init:openaiSpeedModel: "gpt-4-turbo"
-  lambda-ssm-init:openaiQualityModel: "gpt-4o"
+  lambda-ssm-init:openaiSpeedModel: "gpt-4.1-mini"
+  lambda-ssm-init:openaiQualityModel: "gpt-4.1"

--- a/pulumi/lambda-ssm-init/components/config.ts
+++ b/pulumi/lambda-ssm-init/components/config.ts
@@ -46,8 +46,8 @@ export function loadConfig() {
             claudeSpeedModel: config.get("claudeSpeedModel") || "claude-3-haiku-20240307",
             claudeQualityModel: config.get("claudeQualityModel") || "claude-3-5-sonnet-20240620",
             openaiApiKey: config.get("openaiApiKey") || "PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY",
-            openaiSpeedModel: config.get("openaiSpeedModel") || "gpt-4-turbo",
-            openaiQualityModel: config.get("openaiQualityModel") || "gpt-4o",
+            openaiSpeedModel: config.get("openaiSpeedModel") || "gpt-4.1-mini",
+            openaiQualityModel: config.get("openaiQualityModel") || "gpt-4.1",
         }
     };
     


### PR DESCRIPTION
以下のファイルでOpenAIモデルを最新版に更新:
- gpt-4o → gpt-4.1
- gpt-4-turbo → gpt-4.1-mini

更新対象:
- Pulumiスタック設定 (lambda-ssm-init)
- Jenkinsパイプライン (pr-complexity-analyzer, technical-docs-writer, auto-insert-doxygen-comment)
- ドキュメント (pulumi/README.md)
