### PR TITLE
[jenkins] fix: AI Workflow OrchestratorのJenkinsfileをOpenAI APIに対応

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/ai-workflow-orchestrator/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/ai-workflow-orchestrator/Jenkinsfile
@@ -14,7 +14,7 @@
  *
  * 認証情報（Jenkins Credentialsで設定）:
  * - claude-code-oauth-token: Claude Agent SDK用OAuthトークン（必須）
- * - anthropic-api-key: ClaudeContentParser用Anthropic APIキー（必須）
+ * - openai-api-key: ContentParser用OpenAI APIキー（必須）
  * - github-token: GitHub API用トークン（必須）
  *
  * 重要: パラメータ定義はこのファイルでは行いません（Job DSLで定義済み）
@@ -29,7 +29,7 @@ pipeline {
             label 'ec2-fleet'
             dir 'scripts/ai-workflow'
             filename 'Dockerfile'
-            args '-v ${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1 -e CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN} -e ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} -e GITHUB_TOKEN=${GITHUB_TOKEN}'
+            args '-v ${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1 -e CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN} -e OPENAI_API_KEY=${OPENAI_API_KEY} -e GITHUB_TOKEN=${GITHUB_TOKEN}'
         }
     }
 
@@ -55,7 +55,7 @@ pipeline {
 
         // 認証情報（Jenkinsクレデンシャルから取得）
         CLAUDE_CODE_OAUTH_TOKEN = credentials('claude-code-oauth-token')
-        ANTHROPIC_API_KEY = credentials('anthropic-api-key')
+        OPENAI_API_KEY = credentials('openai-api-key')
         GITHUB_TOKEN = credentials('github-token')
     }
 


### PR DESCRIPTION
- 認証情報コメント: anthropic-api-key → openai-api-key
- Docker args環境変数: ANTHROPIC_API_KEY → OPENAI_API_KEY
- Jenkins Credentials: anthropic-api-key → openai-api-key

関連Issue: #352
関連コミット: 4ee4157