### PR TITLE
[ai-workflow-v2] fix: testingフェーズのmaxTurns増加とNODE_ENV削除

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/ai-workflow-orchestrator/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/ai-workflow-orchestrator/Jenkinsfile
@@ -62,9 +62,6 @@ pipeline {
     }
 
     environment {
-        // Node.js実行環境
-        NODE_ENV = 'production'
-
         // Claude Agent SDK設定（Bashコマンド承認スキップ）
         CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS = '1'
         CLAUDE_CODE_CREDENTIALS_PATH = "/home/node/.claude-code/credentials.json"

--- a/scripts/ai-workflow-v2/src/phases/testing.ts
+++ b/scripts/ai-workflow-v2/src/phases/testing.ts
@@ -44,7 +44,7 @@ export class TestingPhase extends BasePhase {
       .replace('{test_scenario_context}', scenarioContext)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 30 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 50 });
 
     if (!fs.existsSync(testResultFile)) {
       return {
@@ -111,7 +111,7 @@ export class TestingPhase extends BasePhase {
       .replace('{implementation_document_path}', implementationRef)
       .replace('{test_scenario_document_path}', scenarioRef);
 
-    const messages = await this.executeWithAgent(reviewPrompt, { maxTurns: 30, logDir: this.reviewDir });
+    const messages = await this.executeWithAgent(reviewPrompt, { maxTurns: 50, logDir: this.reviewDir });
     const reviewResult = await this.contentParser.parseReviewResult(messages);
 
     const reviewFile = path.join(this.reviewDir, 'result.md');
@@ -180,7 +180,7 @@ export class TestingPhase extends BasePhase {
 
     const oldMtime = fs.existsSync(testResultFile) ? fs.statSync(testResultFile).mtimeMs : null;
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 30, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 50, logDir: this.reviseDir });
 
     if (!fs.existsSync(testResultFile)) {
       return {


### PR DESCRIPTION
testingフェーズで失敗していた問題を修正

問題1: maxTurnsが不足（30ターンで打ち切り）
- testing.ts: execute/review/reviseの全メソッドでmaxTurns 30→50に変更
- テスト実行は時間がかかるため、十分なターン数を確保

問題2: NODE_ENV=productionがテスト実行を妨げる
- Jenkinsfile: NODE_ENV='production'を削除
- この設定により npm install --include=dev が正しくdevDependenciesを インストールできるようになり、Jestなどのテストツールが利用可能に

これにより、testingフェーズでのテスト実行が正常に完了する