### PR TITLE
[jenkins] fix: ドラフトPRフィルター設定の重複を削除

### DIFF
--- a/jenkins/jobs/dsl/code-quality-checker/code_quality_reflection_cloud_api_multibranch_job.groovy
+++ b/jenkins/jobs/dsl/code-quality-checker/code_quality_reflection_cloud_api_multibranch_job.groovy
@@ -31,18 +31,13 @@ multibranchPipelineJob(fullJobName) {
                     // ブランチ検出の設定
                     traits {
                         gitHubPullRequestDiscovery {
-                            strategyId(2)  // プルリクエストのHEADとマージ後の両方を検出
+                            strategyId(2)  // The current pull request revision (PRのHEADのみ)
                         }
-                        gitHubIgnoreDraftPullRequestFilter()
+                        gitHubIgnoreDraftPullRequestFilter()  // ドラフトPRを無視
                     }
                 }
             }
         }
-    }
-
-    configure { node ->
-        def traitsNode = node / 'sources' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-        traitsNode.appendNode('org.jenkinsci.plugins.github__branch__source.IgnoreDraftPullRequestFilterTrait')
     }
     
     // 孤立したアイテム戦略


### PR DESCRIPTION
- configure ブロックで重複していた IgnoreDraftPullRequestFilterTrait を削除
- traits ブロック内の gitHubIgnoreDraftPullRequestFilter() のみを使用
- strategyId(2) のコメントを正確な説明に修正（PRのHEADのみ）