### PR TITLE
[jenkins] AI Workflowフォルダを汎用フォルダのみに変更

### DIFF
--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
@@ -6,21 +6,12 @@
  * パラメータ数: 20個（14個 + APIキー6個）
  */
 
-// リポジトリ情報を取得
-def repositories = jenkinsManagedRepositories.collect { name, repo ->
-    [
-        name: name,
-        url: repo.httpsUrl,
-        credentialsId: repo.credentialsId
-    ]
-}
-
-// 汎用フォルダ定義
+// 汎用フォルダ定義（Develop 1 + Stable 9）
 def genericFolders = [
-    [name: 'develop-generic', displayName: '汎用 - Develop', branch: '*/develop'],
-    [name: 'main-generic-1', displayName: '汎用 - Main #1', branch: '*/main'],
-    [name: 'main-generic-2', displayName: '汎用 - Main #2', branch: '*/main']
-]
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
 
 // 共通設定を取得
 def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
@@ -219,15 +210,6 @@ Claude実行モードで使用されます
         // ジョブの無効化状態
         disabled(false)
     }
-}
-
-// 各リポジトリのジョブを作成
-repositories.each { repo ->
-    createJob(
-        "AI_Workflow/${repo.name}/${jobConfig.name}",
-        "リポジトリ: ${repo.name}",
-        '*/main'
-    )
 }
 
 // 汎用フォルダ用ジョブを作成

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
@@ -6,21 +6,12 @@
  * パラメータ数: 14個（8個 + APIキー6個）
  */
 
-// リポジトリ情報を取得
-def repositories = jenkinsManagedRepositories.collect { name, repo ->
-    [
-        name: name,
-        url: repo.httpsUrl,
-        credentialsId: repo.credentialsId
-    ]
-}
-
-// 汎用フォルダ定義
+// 汎用フォルダ定義（Develop 1 + Stable 9）
 def genericFolders = [
-    [name: 'develop-generic', displayName: '汎用 - Develop', branch: '*/develop'],
-    [name: 'main-generic-1', displayName: '汎用 - Main #1', branch: '*/main'],
-    [name: 'main-generic-2', displayName: '汎用 - Main #2', branch: '*/main']
-]
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
 
 // 共通設定を取得
 def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
@@ -197,15 +188,6 @@ Claude実行モードで使用されます
         // ジョブの無効化状態
         disabled(false)
     }
-}
-
-// 各リポジトリのジョブを作成
-repositories.each { repo ->
-    createJob(
-        "AI_Workflow/${repo.name}/${jobConfig.name}",
-        "リポジトリ: ${repo.name}",
-        '*/main'
-    )
 }
 
 // 汎用フォルダ用ジョブを作成

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
@@ -6,21 +6,12 @@
  * パラメータ数: 21個（all_phasesの14個 + PRESET + APIキー6個）
  */
 
-// リポジトリ情報を取得
-def repositories = jenkinsManagedRepositories.collect { name, repo ->
-    [
-        name: name,
-        url: repo.httpsUrl,
-        credentialsId: repo.credentialsId
-    ]
-}
-
-// 汎用フォルダ定義
+// 汎用フォルダ定義（Develop 1 + Stable 9）
 def genericFolders = [
-    [name: 'develop-generic', displayName: '汎用 - Develop', branch: '*/develop'],
-    [name: 'main-generic-1', displayName: '汎用 - Main #1', branch: '*/main'],
-    [name: 'main-generic-2', displayName: '汎用 - Main #2', branch: '*/main']
-]
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
 
 // 共通設定を取得
 def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
@@ -237,15 +228,6 @@ Claude実行モードで使用されます
         // ジョブの無効化状態
         disabled(false)
     }
-}
-
-// 各リポジトリのジョブを作成
-repositories.each { repo ->
-    createJob(
-        "AI_Workflow/${repo.name}/${jobConfig.name}",
-        "リポジトリ: ${repo.name}",
-        '*/main'
-    )
 }
 
 // 汎用フォルダ用ジョブを作成

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
@@ -6,21 +6,12 @@
  * パラメータ数: 18個（12個 + APIキー6個）
  */
 
-// リポジトリ情報を取得
-def repositories = jenkinsManagedRepositories.collect { name, repo ->
-    [
-        name: name,
-        url: repo.httpsUrl,
-        credentialsId: repo.credentialsId
-    ]
-}
-
-// 汎用フォルダ定義
+// 汎用フォルダ定義（Develop 1 + Stable 9）
 def genericFolders = [
-    [name: 'develop-generic', displayName: '汎用 - Develop', branch: '*/develop'],
-    [name: 'main-generic-1', displayName: '汎用 - Main #1', branch: '*/main'],
-    [name: 'main-generic-2', displayName: '汎用 - Main #2', branch: '*/main']
-]
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
 
 // 共通設定を取得
 def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
@@ -243,15 +234,6 @@ Claude実行モードで使用されます
         // ジョブの無効化状態
         disabled(false)
     }
-}
-
-// 各リポジトリのジョブを作成
-repositories.each { repo ->
-    createJob(
-        "AI_Workflow/${repo.name}/${jobConfig.name}",
-        "リポジトリ: ${repo.name}",
-        '*/main'
-    )
 }
 
 // 汎用フォルダ用ジョブを作成

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
@@ -6,21 +6,12 @@
  * パラメータ数: 19個（13個 + APIキー6個）
  */
 
-// リポジトリ情報を取得
-def repositories = jenkinsManagedRepositories.collect { name, repo ->
-    [
-        name: name,
-        url: repo.httpsUrl,
-        credentialsId: repo.credentialsId
-    ]
-}
-
-// 汎用フォルダ定義
+// 汎用フォルダ定義（Develop 1 + Stable 9）
 def genericFolders = [
-    [name: 'develop-generic', displayName: '汎用 - Develop', branch: '*/develop'],
-    [name: 'main-generic-1', displayName: '汎用 - Main #1', branch: '*/main'],
-    [name: 'main-generic-2', displayName: '汎用 - Main #2', branch: '*/main']
-]
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
 
 // 共通設定を取得
 def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
@@ -225,15 +216,6 @@ Claude実行モードで使用されます
         // ジョブの無効化状態
         disabled(false)
     }
-}
-
-// 各リポジトリのジョブを作成
-repositories.each { repo ->
-    createJob(
-        "AI_Workflow/${repo.name}/${jobConfig.name}",
-        "リポジトリ: ${repo.name}",
-        '*/main'
-    )
 }
 
 // 汎用フォルダ用ジョブを作成

--- a/jenkins/jobs/pipeline/_seed/job-creator/folder-config.yaml
+++ b/jenkins/jobs/pipeline/_seed/job-creator/folder-config.yaml
@@ -353,114 +353,169 @@ folders:
       * **claude-api-key**: Claude API キー（Jenkinsクレデンシャル）
       * **github-token**: GitHub Token（Jenkinsクレデンシャル）
 
-  # Issue #456: AI Workflow用の汎用フォルダを追加
-  # 追加日: 2025-01-17
-  # URL: https://github.com/tielec/infrastructure-as-code/issues/456
+  # Issue #470: AI Workflow用フォルダをリポジトリ非依存の汎用フォルダのみに変更
+  # 更新日: 2025-01-17
+  # URL: https://github.com/tielec/infrastructure-as-code/issues/470
   #
-  # 背景:
-  # - 特定リポジトリに依存しない汎用的なワークフロー実行環境が必要
-  # - developブランチ用（最新機能のテスト）とmainブランチ用（安定バージョン）を分離
-  # - main用は並行利用可能にするため2つ用意
+  # 構成:
+  # - Develop: 1フォルダ（最新機能のテスト用）
+  # - Stable: 9フォルダ（安定バージョン、並行実行可能）
 
-  # AI Workflow - develop用汎用フォルダ
-  - path: "AI_Workflow/develop-generic"
-    displayName: "汎用 - Develop"
+  # AI Workflow - Develop用フォルダ
+  - path: "AI_Workflow/develop"
+    displayName: "AI Workflow Executor - Develop"
     description: |
-      developブランチ用の汎用ワークフロー実行環境
+      developブランチ用のワークフロー実行環境
 
       ### 用途
       - ai-workflow-agentの**最新バージョン**（developブランチ）を使用
       - 新機能のテスト、実験的な利用
-      - 特定リポジトリに依存しない汎用的なワークフロー
 
       ### 対象ブランチ
       - ai-workflow-agent: **develop**
 
-      ### 推奨の使い方
-      - 最新機能の検証
-      - 新しいワークフローのテスト
-      - リポジトリ横断的なタスク実行
-
       ### 注意事項
       - 開発中の機能のため、動作が不安定な場合があります
-      - 本番環境での利用は避けてください
-      - 安定した動作が必要な場合はmain用フォルダを使用してください
+      - 安定した動作が必要な場合はStableフォルダを使用してください
 
-  # AI Workflow - main用汎用フォルダ（1つ目）
-  - path: "AI_Workflow/main-generic-1"
-    displayName: "汎用 - Main #1"
+  # AI Workflow - Stable用フォルダ（1〜9）
+  - path: "AI_Workflow/stable-1"
+    displayName: "AI Workflow Executor - Stable 1"
     description: |
-      mainブランチ用の汎用ワークフロー実行環境（1つ目）
+      mainブランチ用のワークフロー実行環境（Stable 1）
 
       ### 用途
       - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
       - 本番環境での利用、安定した動作が求められる場合
-      - 特定リポジトリに依存しない汎用的なワークフロー
 
       ### 対象ブランチ
       - ai-workflow-agent: **main**
 
-      ### 推奨の使い方
-      - 本番環境でのワークフロー実行
-      - 安定性が求められるタスク
-      - リポジトリ横断的なタスク実行
-
       ### 並行利用について
-      - main用フォルダは2つあり、複数のワークフローを同時実行可能です
-      - 使用中は`main-generic-2`をご利用ください
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
 
-  # AI Workflow - main用汎用フォルダ（2つ目）
-  - path: "AI_Workflow/main-generic-2"
-    displayName: "汎用 - Main #2"
+  - path: "AI_Workflow/stable-2"
+    displayName: "AI Workflow Executor - Stable 2"
     description: |
-      mainブランチ用の汎用ワークフロー実行環境（2つ目）
+      mainブランチ用のワークフロー実行環境（Stable 2）
 
       ### 用途
       - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
       - 本番環境での利用、安定した動作が求められる場合
-      - 特定リポジトリに依存しない汎用的なワークフロー
 
       ### 対象ブランチ
       - ai-workflow-agent: **main**
 
-      ### 推奨の使い方
-      - 本番環境でのワークフロー実行
-      - 安定性が求められるタスク
-      - リポジトリ横断的なタスク実行
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-3"
+    displayName: "AI Workflow Executor - Stable 3"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 3）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
 
       ### 並行利用について
-      - main用フォルダは2つあり、複数のワークフローを同時実行可能です
-      - `main-generic-1`が使用中の場合はこちらをご利用ください
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-4"
+    displayName: "AI Workflow Executor - Stable 4"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 4）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-5"
+    displayName: "AI Workflow Executor - Stable 5"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 5）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-6"
+    displayName: "AI Workflow Executor - Stable 6"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 6）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-7"
+    displayName: "AI Workflow Executor - Stable 7"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 7）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-8"
+    displayName: "AI Workflow Executor - Stable 8"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 8）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-9"
+    displayName: "AI Workflow Executor - Stable 9"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 9）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
 
 # 動的フォルダ生成ルール
 dynamic_folders:
-  # AI Workflowのリポジトリ別フォルダ
-  - parent_path: "AI_Workflow"
-    source: "jenkins-managed-repositories"
-    template:
-      path_suffix: "{name}"
-      displayName: "AI Workflow - {name}"
-      description: |
-        {name}リポジトリのAI駆動開発ワークフロージョブ
-
-        ### 提供ジョブ
-        * **all_phases** - 全フェーズ一括実行（14パラメータ）
-        * **preset** - プリセット実行（15パラメータ）
-        * **single_phase** - 単一フェーズ実行（13パラメータ）
-        * **rollback** - フェーズ差し戻し実行（12パラメータ）
-        * **auto_issue** - 自動Issue作成（8パラメータ）
-
-        ### 実行モード
-        各ジョブは実行モードが固定されており、必要なパラメータのみを表示します。
-
-        ### 推奨の使い方
-        1. **通常の開発**: `preset` → `implementation`を選択
-        2. **軽微な修正**: `preset` → `quick-fix`を選択
-        3. **テストのみ追加**: `preset` → `testing`を選択
-        4. **特定フェーズのみ**: `single_phase`でフェーズを指定
-        5. **レビュー修正**: `rollback`で差し戻し先を指定
-        6. **Issue探索**: `auto_issue`でバグや改善点を検出
-
   # Code Quality Checkerのリポジトリ別フォルダ
   - parent_path: "Code_Quality_Checker"
     source: "jenkins-managed-repositories"


### PR DESCRIPTION
- リポジトリごとのジョブ生成ロジックを削除
- 汎用フォルダを新命名規則に変更:
  - AI Workflow Executor - Develop (1フォルダ)
  - AI Workflow Executor - Stable 1-9 (9フォルダ)
- folder-config.yamlのフォルダ定義を更新
- dynamic_foldersからAI Workflow定義を削除

Fixes #470