### PR TITLE
[jenkins][pulumi] fix: Issue #484のECS Fargate設定とIAM権限を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@
   - プラグインの変更
   - セキュリティ設定の変更
   - トラブルシューティング情報の追加
-- **ECS Fargateエージェント**: Pulumi `jenkins-agent`スタックがECS Cluster/Task Definition/ECR/Log GroupとSSM `/agent/ecs-*` を管理。`amazon-ecs`プラグインやJCasC `ecs-fargate` 設定を変える場合はPulumi側と`application-configure-with-casc.sh`も同期すること
+- **⚠️ ECS Fargate設定の重要な注意**:
+  - `jenkins.yaml.template`のECS設定は`amazon-ecs`プラグインの仕様に厳密に従うこと
+  - **サポートされていない設定項目**: `idleTerminationMinutes`, `maxInstances`（これらを含めるとJenkins起動失敗）
+  - **必須のIAM権限**: ControllerのIAM Roleに`ecs:RunTask`, `ecs:StopTask`, `ecs:DescribeTasks`等のECS操作権限が必要
+  - Pulumi `jenkins-controller`スタックにECS Fargateポリシーが定義されていること
 
 ### ⚠️ Jenkinsパラメータ定義ルール
 

--- a/scripts/jenkins/casc/jenkins.yaml.template
+++ b/scripts/jenkins/casc/jenkins.yaml.template
@@ -84,9 +84,14 @@ jenkins:
             executionRole: "${ECS_EXECUTION_ROLE_ARN}"
             taskrole: "${ECS_TASK_ROLE_ARN}"
             cpu: 512
+            memory: 0
             memoryReservation: 1024
-            idleTerminationMinutes: 5
-            maxInstances: 5
+            cpuArchitecture: "X86_64"
+            operatingSystemFamily: "LINUX"
+            defaultCapacityProvider: false
+            enableExecuteCommand: false
+            privileged: false
+            sharedMemorySize: 0
             inheritFrom: ""
             containerUser: "jenkins"
   nodes:


### PR DESCRIPTION
- jenkins.yaml.template: サポートされていないidleTerminationMinutes/maxInstancesを削除
- jenkins.yaml.template: amazon-ecsプラグイン仕様に準拠した設定項目を追加
- jenkins-controller/index.ts: ControllerにECS Fargate管理用IAMポリシーを追加
- CLAUDE.md: ECS Fargate設定の注意事項を詳細化