### PR TITLE
[jenkins] update: pulumi_stack_action_test job にAGENT_LABELパラメータを追加

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
@@ -36,7 +36,8 @@ pipelineJob(fullJobName) {
         // === 基本パラメータ ===
         choiceParam('ENVIRONMENT', ['dev'], 'デプロイ先環境')
         choiceParam('ACTION', ['preview', 'deploy', 'destroy'], '実行するアクション')
-        
+        choiceParam('AGENT_LABEL', ['ec2-fleet-small', 'ec2-fleet-medium', 'ec2-fleet-micro'], 'Jenkins エージェントのラベル')
+
         // === AWS認証情報 ===
         stringParam('AWS_ACCESS_KEY_ID', '', 'AWS Access Key ID')
         nonStoredPasswordParam('AWS_SECRET_ACCESS_KEY', 'AWS Secret Access Key')

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
@@ -6,7 +6,7 @@
  */
 pipeline {
     agent {
-        label 'ec2-fleet'
+        label params.AGENT_LABEL ?: 'ec2-fleet-small'
     }
     
     environment {


### PR DESCRIPTION
- DSLファイルにAGENT_LABEL choiceパラメータを追加
  - 選択肢: ec2-fleet-small, ec2-fleet-medium, ec2-fleet-micro
- Jenkinsfileのagent labelをパラメータ化
  - ハードコードされた 'ec2-fleet' を params.AGENT_LABEL に置き換え
  - デフォルト値: 'ec2-fleet-small'

Related: #506