### PR TITLE
[jenkins] update: AGENT_LABELのデフォルトを ec2-fleet-medium に変更

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
@@ -36,7 +36,7 @@ pipelineJob(fullJobName) {
         // === 基本パラメータ ===
         choiceParam('ENVIRONMENT', ['dev'], 'デプロイ先環境')
         choiceParam('ACTION', ['preview', 'deploy', 'destroy'], '実行するアクション')
-        choiceParam('AGENT_LABEL', ['ec2-fleet-small', 'ec2-fleet-medium', 'ec2-fleet-micro'], 'Jenkins エージェントのラベル')
+        choiceParam('AGENT_LABEL', ['ec2-fleet-medium', 'ec2-fleet-small', 'ec2-fleet-micro'], 'Jenkins エージェントのラベル')
 
         // === AWS認証情報 ===
         stringParam('AWS_ACCESS_KEY_ID', '', 'AWS Access Key ID')

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
@@ -6,7 +6,7 @@
  */
 pipeline {
     agent {
-        label params.AGENT_LABEL ?: 'ec2-fleet-small'
+        label params.AGENT_LABEL ?: 'ec2-fleet-medium'
     }
     
     environment {


### PR DESCRIPTION
- small インスタンスではJavaScript heap out of memoryエラーが発生
- デフォルトを ec2-fleet-medium に変更
  - DSL: choiceParam の順序を変更（最初がデフォルト）
  - Jenkinsfile: フォールバック値を 'ec2-fleet-medium' に変更

Related: #506