### PR TITLE
[pulumi] fix: jenkins-ssm-init/Pulumi.dev.yamlを削除（passphrase不整合の解消）

### DIFF
--- a/pulumi/jenkins-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/jenkins-ssm-init/Pulumi.dev.yaml
@@ -1,1 +1,0 @@
-encryptionsalt: v1:6j7EZ6bD8d4=:v1:KhBveWMEcP7pV6Eq:j0vXr4mEXcJOurNw/a9koLl3UR8eTQ==


### PR DESCRIPTION
## 概要

PR #569（Issue #568 対応）で誤ってコミットされた `pulumi/jenkins-ssm-init/Pulumi.dev.yaml` を削除する。

## 背景

PR #569 のテスト実行時に Pulumi が `Pulumi.dev.yaml` を新規生成し、そのまま AI workflow agent によってコミットされていた。

このファイル内の `encryptionsalt` 値が S3 バックエンド上に既に存在するスタックの暗号化 salt と不整合を起こしていたため、Ansible からの Pulumi 実行時に以下のエラーが発生し、デプロイがブロックされていた。

```
error: getting stack configuration: get stack secrets manager: incorrect passphrase
```

## 変更内容

- `pulumi/jenkins-ssm-init/Pulumi.dev.yaml` を削除

ファイルを削除することで、Pulumi は S3 バックエンド上の既存スタック設定（正しい encryptionsalt を含む）を参照するようになり、SSM Parameter Store から取得した passphrase で正しく復号できるようになる。

## 影響範囲

- `pulumi/jenkins-ssm-init` スタックのデプロイのみに影響
- 他の Pulumi スタック（`jenkins-ssm-backup-s3`, `lambda-ssm-init` 等）の `Pulumi.dev.yaml` は既存スタックと整合しているため変更なし

## テスト

- [ ] マージ後、`ansible-playbook playbooks/jenkins/deploy/deploy_jenkins_ssm_init.yml -e "env=dev"` が成功すること

## 関連

- 親 Issue: #568
- 親 PR: #569