### PR TITLE
[scripts] fix: controller-mount-efs.shの再帰chown/chmodを冪等化（Issue #572）

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -313,6 +313,7 @@ ansible-playbook playbooks/lambda_setup_pipeline.yml -e "env=dev"
 | `JENKINS_VERSION` | Jenkinsバージョン | 2.426.1 |
 | `JENKINS_PORT` | Jenkinsポート | 8080 |
 | `JENKINS_ADMIN_USER` | 管理者ユーザー | admin |
+| `FORCE_CHOWN` | `controller-mount-efs.sh` の所有権・パーミッション再帰処理を強制実行 | false |
 
 ### Lambda関連環境変数
 

--- a/scripts/jenkins/shell/controller-mount-efs.sh
+++ b/scripts/jenkins/shell/controller-mount-efs.sh
@@ -113,10 +113,35 @@ if ! id jenkins &>/dev/null; then
   useradd -m -d $JENKINS_HOME_DIR -g jenkins jenkins
 fi
 
-# 所有権とパーミッションを設定
-chown -R jenkins:jenkins $JENKINS_HOME_DIR
-find $JENKINS_HOME_DIR -type d -exec chmod 755 {} \;
-find $JENKINS_HOME_DIR -type f -exec chmod 644 {} \; 2>/dev/null || true
+# 必須トップレベルディレクトリの所有権は常に確実に設定する
+# mkdirで新規作成されたサブディレクトリ（root所有）に対応するため、浅い処理として実施
+# EFS上でも一階層のみなので高速
+chown jenkins:jenkins "$JENKINS_HOME_DIR" 2>/dev/null || true
+chown jenkins:jenkins "$JENKINS_HOME_DIR"/{plugins,jobs,secrets,nodes,logs,init.groovy.d} 2>/dev/null || true
+
+# 配下の所有権・パーミッションの再帰処理は冪等化する
+# EFS（NFS）上の再帰chown/chmodはファイル数に比例して数十分以上かかるため、
+# トップレベルが既に正しい状態の場合は再帰処理をスキップする
+# 強制実行が必要な場合（リカバリ等）は環境変数 FORCE_CHOWN=true を指定する
+CURRENT_OWNER=$(stat -c '%U:%G' "$JENKINS_HOME_DIR" 2>/dev/null || echo "")
+CURRENT_MODE=$(stat -c '%a' "$JENKINS_HOME_DIR" 2>/dev/null || echo "")
+
+if [ "$CURRENT_OWNER" = "jenkins:jenkins" ] && [ "$CURRENT_MODE" = "755" ] && [ "${FORCE_CHOWN:-false}" != "true" ]; then
+  log "所有権・パーミッションは既に正しい状態（owner=$CURRENT_OWNER, mode=$CURRENT_MODE）"
+  log "再帰処理をスキップしてEFSパフォーマンスを確保します"
+  log "強制再実行が必要な場合は FORCE_CHOWN=true を指定してください"
+else
+  if [ "${FORCE_CHOWN:-false}" = "true" ]; then
+    log "FORCE_CHOWN=true により所有権・パーミッションの再帰処理を強制実行します"
+  else
+    log "所有権・パーミッションを再帰設定中（current owner=$CURRENT_OWNER, mode=$CURRENT_MODE）..."
+    log "注意: EFS上ではファイル数に応じて時間がかかります"
+  fi
+  chown -R jenkins:jenkins "$JENKINS_HOME_DIR"
+  find "$JENKINS_HOME_DIR" -type d -exec chmod 755 {} \;
+  find "$JENKINS_HOME_DIR" -type f -exec chmod 644 {} \; 2>/dev/null || true
+  log "再帰処理が完了しました"
+fi
 
 # シンボリックリンクの設定
 SYSTEM_JENKINS_HOME="/var/lib/jenkins"


### PR DESCRIPTION
## 概要

Issue #572 の対応。`scripts/jenkins/shell/controller-mount-efs.sh` の `chown -R` と `find ... chmod` がデプロイのたびに無条件で再帰実行され、EFS（NFS）上のファイル数が多い環境でデプロイが数十分〜数時間ブロックされる問題を解消する。

## 背景

- Issue #568 のデプロイ作業中、Phase 3（`deploy_jenkins_config.yml`）の EFS マウント処理が `chown -R jenkins:jenkins /mnt/efs/jenkins` で長時間ブロックされた
- EFS は NFS プロトコル経由のため、各ファイル操作にネットワーク往復遅延が発生
- 既存の冪等性チェックは EFS マウント自体のみで、所有権・パーミッションは無条件再帰実行されていた

## 変更内容

### `scripts/jenkins/shell/controller-mount-efs.sh`

1. **トップレベル + 必須サブディレクトリへの浅い chown を追加**
   - `mkdir -p` で新規作成されるサブディレクトリ（plugins, jobs, secrets, nodes, logs, init.groovy.d）が root 所有のまま残る問題を防ぐ
   - 一階層のみの処理なので EFS でも高速

2. **再帰 chown/chmod に冪等性判定を追加**
   - `stat -c '%U:%G'` と `stat -c '%a'` でトップディレクトリの状態を確認
   - `jenkins:jenkins` かつ `755` であれば再帰処理をスキップ
   - スキップ判定の根拠: このスクリプトが `$JENKINS_HOME_DIR` の所有権を設定する唯一の箇所であり、トップが正しければ配下も同じ状態と仮定できる

3. **`FORCE_CHOWN` 環境変数を追加**
   - リカバリ等で強制再実行が必要な場合に `FORCE_CHOWN=true` を指定して従来動作にフォールバック可能

4. **状態ログの追加**
   - スキップ時・実行時ともに現在の owner/mode をログ出力し、運用時の追跡を容易化

### `scripts/README.md`

- Jenkins 関連環境変数表に `FORCE_CHOWN` を追加

## 期待効果

- 既存環境への再デプロイ時、EFS マウント後の冗長な再帰処理（数十分〜数時間）がスキップされる
- 初回マウント時・所有権が崩れている時のみ再帰処理が走る
- リカバリが必要な場合は `FORCE_CHOWN=true` で従来動作を呼び出せる

## 影響範囲

- `deploy_jenkins_config.yml` 実行時の Phase（EFS マウント・初期化）
- `jenkins_setup_pipeline.yml` 実行時の同フェーズ
- 既存環境への影響: なし（冪等化のみ、初回実行や所有権崩壊時の挙動は変わらない）

## テスト

- [x] `bash -n` による構文チェック PASS
- [ ] 既にマウント済み環境でスクリプト再実行 → 再帰処理スキップを確認
- [ ] 新規環境（または `FORCE_CHOWN=true`）で再帰処理が走ることを確認
- [ ] スキップ時のログが期待通り出力されることを確認

## 関連

- Issue: #572
- 発見契機: PR #569 / Issue #568 のデプロイ作業