### PR TITLE
[jenkins] fix: JCasCのexcludeClientIPFromCrumb属性を削除（Jenkins 2.555.1対応）

### DIFF
--- a/jenkins/CONTRIBUTION.md
+++ b/jenkins/CONTRIBUTION.md
@@ -1202,10 +1202,11 @@ def password = 'hardcoded-password'  // 絶対NG！
 
 ```groovy
 // JCasC設定
+// Jenkins 2.452前後で excludeClientIPFromCrumb 属性は削除済み
+// 現行版ではクライアントIP除外がデフォルト動作
 jenkins:
   crumbIssuer:
     standard:
-      excludeClientIPFromCrumb: false
 ```
 
 #### 3.1.3 権限管理

--- a/scripts/jenkins/casc/jenkins.yaml.template
+++ b/scripts/jenkins/casc/jenkins.yaml.template
@@ -11,7 +11,6 @@ jenkins:
       enableCaptcha: false
   crumbIssuer:
     standard:
-      excludeClientIPFromCrumb: true
   markupFormatter:
     markdownFormatter:
       disableSyntaxHighlighting: false


### PR DESCRIPTION
## 概要

Issue #574 対応。Jenkins 2.555.1 で JCasC 初期化が以下のエラーで失敗し、Jenkins Controller の起動がブロックされていた問題を修正する。

\`\`\`
io.jenkins.plugins.casc.UnknownAttributesException:
Invalid configuration elements for type: DefaultCrumbIssuer : excludeClientIPFromCrumb
\`\`\`

## 原因

Jenkins 2.452 前後で \`DefaultCrumbIssuer\` から \`excludeClientIPFromCrumb\` 属性が削除された。本リポジトリの SSM パラメータ \`jenkins-version\` は \`latest\` 指定（\`pulumi/jenkins-ssm-init/index.ts:104\`）のため、デプロイ時に最新版（2.555.1）が導入され、本問題が表面化した。

## 変更内容

### \`scripts/jenkins/casc/jenkins.yaml.template\`

\`\`\`yaml
# 変更前
crumbIssuer:
  standard:
    excludeClientIPFromCrumb: true   # ← 削除

# 変更後
crumbIssuer:
  standard:
\`\`\`

### \`jenkins/CONTRIBUTION.md\`

ドキュメント中の同じサンプルコードも修正し、削除理由をコメントとして追加。

## 挙動への影響

\`excludeClientIPFromCrumb: true\` は「crumb 生成時にクライアント IP を除外する」設定で、ALB / Reverse Proxy 経由で接続元 IP が変わる環境での crumb 検証安定化のために使われていた。

現行 Jenkins ではこの挙動が**デフォルト**となったため、属性削除によっても従来と同等の動作が維持される（ALB 経由の認証フローへの影響なし）。

## テスト

- [x] YAML パース成功（Python yaml.safe_load）
- [ ] マージ後に Ansible デプロイを再実行
- [ ] Jenkins UI への /login アクセスが 200 で応答すること
- [ ] \`https://<jenkins-url>/monitoring\` で JavaMelody が起動していること
- [ ] CSRF crumb 検証が引き続き動作すること（ALB 経由ジョブ実行で確認）

## 影響範囲

- Jenkins Controller の起動: **修正後は正常起動可能**
- 既存の認証・ジョブ実行フロー: 影響なし（crumb 動作はデフォルトに移行するのみ）
- 他環境（dev/staging/prod）: 同じ JCasC テンプレートを使用しているため、本修正で全環境が解消される

## 関連

- Issue: #574
- 親 Issue: #568（このデプロイ作業中に発見）