### PR TITLE
[jenkins] fix: crumbIssuer.standardに空マップ{}を明示（PR #575の追加修正）

### DIFF
--- a/jenkins/CONTRIBUTION.md
+++ b/jenkins/CONTRIBUTION.md
@@ -1204,9 +1204,10 @@ def password = 'hardcoded-password'  // 絶対NG！
 // JCasC設定
 // Jenkins 2.452前後で excludeClientIPFromCrumb 属性は削除済み
 // 現行版ではクライアントIP除外がデフォルト動作
+// 空のマップ {} を明示することでJCasCがstandard CrumbIssuerを正しく認識する
 jenkins:
   crumbIssuer:
-    standard:
+    standard: {}
 ```
 
 #### 3.1.3 権限管理

--- a/scripts/jenkins/casc/jenkins.yaml.template
+++ b/scripts/jenkins/casc/jenkins.yaml.template
@@ -10,7 +10,7 @@ jenkins:
       allowsSignup: false
       enableCaptcha: false
   crumbIssuer:
-    standard:
+    standard: {}
   markupFormatter:
     markdownFormatter:
       disableSyntaxHighlighting: false


### PR DESCRIPTION
## 概要

PR #575（Issue #574）の追加修正。\`excludeClientIPFromCrumb\` 属性を削除した結果、以下のような構造になり、YAML 上で \`standard\` の値が null になっていた。

\`\`\`yaml
crumbIssuer:
  standard:    # ← 値なし = null として解釈される
\`\`\`

JCasC は \`standard:\` が null だと「設定値なしの standard CrumbIssuer を使用」とは認識せず、結果として依然として Jenkins 起動に失敗していた。

## 修正内容

\`\`\`yaml
# 変更前（PR #575の状態）
crumbIssuer:
  standard:

# 変更後
crumbIssuer:
  standard: {}
\`\`\`

空マップ \`{}\` を明示することで、JCasC に「設定値なしの standard CrumbIssuer を使用する」意図を正しく伝える。

## 検証

- [x] YAML パース結果が \`{'standard': {}}\` （非 null マップ）になることを確認
- [ ] マージ後、Ansible デプロイ再実行で Jenkins が正常起動すること
- [ ] \`/login\` への HTTP 200 応答
- [ ] CSRF crumb 検証が引き続き動作

## 変更ファイル

| ファイル | 変更 |
|---|---|
| \`scripts/jenkins/casc/jenkins.yaml.template\` | \`standard:\` → \`standard: {}\` |
| \`jenkins/CONTRIBUTION.md\` | ドキュメント中のサンプルも同様に修正、コメント追記 |

## 補足：簡略形について

JCasC のモダンな短縮形 \`crumbIssuer: \"standard\"\` も技術的には可能だが、本PRでは既存の構造を維持する \`standard: {}\` を採用した。差分が最小で、設定追加が必要になった場合の拡張も容易なため。

## 関連

- 親 Issue: #574
- 直前 PR: #575（不完全だった修正）
- 親 Issue: #568（一連の運用改善作業）