### PR TITLE
[jenkins] fix: commitAndPushChangesのベースブランチcheckout失敗を修正 (#583)

### DIFF
--- a/jenkins/jobs/shared/src/jp/co/tielec/git/GitClientBase.groovy
+++ b/jenkins/jobs/shared/src/jp/co/tielec/git/GitClientBase.groovy
@@ -441,10 +441,11 @@ class GitClientBase implements Serializable {
             git stash push -u || echo "退避する変更がないか退避操作に失敗しました (続行します)"
             
             # ベースブランチを最新に更新
+            # Jenkinsのワークスペースはdetached HEADかつfetch refspecが狭い場合があるため、
+            # 明示的なrefspecでフェッチし、checkout -B でローカルブランチを作成/リセットする
             echo "originからフェッチし、ベースブランチ '${baseBranchEsc}' を最新の状態にします..."
-            git fetch origin --prune
-            git checkout '${baseBranchEsc}'
-            git reset --hard origin/'${baseBranchEsc}'
+            git fetch origin --prune '+refs/heads/${baseBranchEsc}:refs/remotes/origin/${baseBranchEsc}'
+            git checkout -B '${baseBranchEsc}' origin/'${baseBranchEsc}'
         """
     }
 


### PR DESCRIPTION
## 概要
共有ライブラリ `gitUtils.commitAndPushChanges`（`GitClientBase.stashChangesAndUpdateBaseBranch`）が、Jenkinsのmultibranchワークスペースで `git checkout <baseBranch>` にpathspecエラーで失敗する問題の修正。

Fixes #583

## 原因
Jenkinsのcheckoutは対象コミットのdetached HEADで、リポジトリのfetch refspecがビルド対象に絞られているため、`git fetch origin --prune` してもローカルに `origin/<baseBranch>` の参照が作られないケースがある（reflection-cloud-api のFAQ埋め込み自動コミットで再現）。

## 変更内容
```diff
- git fetch origin --prune
- git checkout '${baseBranchEsc}'
- git reset --hard origin/'${baseBranchEsc}'
+ git fetch origin --prune '+refs/heads/${baseBranchEsc}:refs/remotes/origin/${baseBranchEsc}'
+ git checkout -B '${baseBranchEsc}' origin/'${baseBranchEsc}'
```

- 明示的なrefspecでベースブランチを確実にフェッチ
- `checkout -B` はローカルブランチの有無に関わらず作成/リセットするため、従来の checkout + reset --hard と同じ最終状態になる（後方互換）

## 影響範囲
commitAndPushChanges を使う全ジョブ（docs-generator系、backup-config等）。いずれも従来動作していたケースでは同一の結果になり、失敗していたdetached HEADケースが救済される。