### PR TITLE
[jenkins] update: pulumi-stack-actionのAGENT_LABELからec2-fleet-microを削除

### DIFF
--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_job.groovy
@@ -70,8 +70,8 @@ pulumiProjects.each { repoKey, repoConfig ->
                 // パラメータ定義
                 parameters {
                     // === AGENT_LABELパラメータ ===
-                    choiceParam('AGENT_LABEL', ['ec2-fleet-micro', 'ec2-fleet-small', 'ec2-fleet-medium'],
-                        'Jenkins エージェントのラベル（micro: 1並列/1GB, small: 2並列/2GB, medium: 3並列/4GB）')
+                    choiceParam('AGENT_LABEL', ['ec2-fleet-small', 'ec2-fleet-medium'],
+                        'Jenkins エージェントのラベル（small: 2並列/2GB, medium: 3並列/4GB）')
 
                     // === 基本パラメータ ===
 

--- a/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
+++ b/jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy
@@ -36,7 +36,7 @@ pipelineJob(fullJobName) {
         // === 基本パラメータ ===
         choiceParam('ENVIRONMENT', ['dev'], 'デプロイ先環境')
         choiceParam('ACTION', ['preview', 'deploy', 'destroy'], '実行するアクション')
-        choiceParam('AGENT_LABEL', ['ec2-fleet-micro', 'ec2-fleet-small', 'ec2-fleet-medium'], 'Jenkins エージェントのラベル')
+        choiceParam('AGENT_LABEL', ['ec2-fleet-small', 'ec2-fleet-medium'], 'Jenkins エージェントのラベル')
 
         // === AWS認証情報 ===
         stringParam('AWS_ACCESS_KEY_ID', '', 'AWS Access Key ID')


### PR DESCRIPTION
Closes #585

## 概要

`jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile` を呼び出す Job DSL 2ファイルの `AGENT_LABEL` 選択肢から `ec2-fleet-micro` を削除し、先頭（デフォルト）を `ec2-fleet-small` に変更しました。

## 背景

micro エージェント（1並列/1GB）上で `npx tsc --noEmit` を実行すると、Node.js のヒープ不足で頻繁に失敗するため。

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_job.groovy` | `AGENT_LABEL` を `['ec2-fleet-small', 'ec2-fleet-medium']` に変更（説明文からも micro を削除） |
| `jenkins/jobs/dsl/infrastructure/infrastructure_pulumi_stack_action_test_job.groovy` | `AGENT_LABEL` を `['ec2-fleet-small', 'ec2-fleet-medium']` に変更 |

Jenkinsfile 側のフォールバックは元々 `ec2-fleet-medium` のため変更なし。

## 補足

他ジョブ（`ansible_playbook_executor`、`pulumi_dashboard`、`ssm_dashboard`、`lambda_verification` 等）にも `ec2-fleet-micro` 先頭の定義が残っていますが、今回は対象外としています。

## 反映手順

マージ後、シードジョブ `Admin_Jobs/job-creator` を実行してジョブ定義を更新してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)