### PR TITLE
[jenkins] fix: Pulumi実行が失敗してもジョブがSUCCESSになる問題を修正

### DIFF
--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/Jenkinsfile
@@ -38,6 +38,13 @@ pipeline {
                 script {
                     currentBuild.displayName = "#${env.BUILD_NUMBER} - ${params.ENVIRONMENT} ${params.ACTION}"
 
+                    // Pulumiアクションのエラー状態を初期化
+                    // 注意: stage の environment{} ブロックで宣言すると、そのブロック配下では
+                    //       environment{} 側の値が優先されて env への書き込みが読み取れなくなるため、
+                    //       ここでグローバルな env として初期化する
+                    env.PULUMI_ACTION_ERROR = 'false'
+                    env.PULUMI_ACTION_ERROR_MESSAGE = ''
+
                     // SSMパラメータから必要な設定を取得
                     def s3BucketName = ssmParameter.get('/bootstrap/pulumi/s3bucket-name', params.AWS_REGION)
                     // SecureStringパラメータは自動的に復号化される
@@ -72,7 +79,6 @@ pipeline {
                 PULUMI_BACKEND_URL       = "${env.PULUMI_BACKEND_URL}"
                 PULUMI_CONFIG_PASSPHRASE = "${env.PULUMI_CONFIG_PASSPHRASE}"
                 PULUMI_SKIP_UPDATE_CHECK = 'true'
-                PULUMI_ACTION_ERROR = 'false'
             }
             stages {
                 stage('Setup Environment') {
@@ -138,21 +144,11 @@ pipeline {
                                         "AWS_SECRET_ACCESS_KEY=${params.AWS_SECRET_ACCESS_KEY}",
                                         "AWS_SESSION_TOKEN=${params.AWS_SESSION_TOKEN ?: ''}"
                                     ]) {
-                                        try {
-                                            executePulumiAction(params.ACTION)
-                                        } catch (Exception e) {
-                                            echo "警告: Pulumiアクション実行中にエラーが発生しました: ${e.message}"
-                                            env.PULUMI_ACTION_ERROR = 'true'
-                                        }
+                                        executePulumiActionSafely(params.ACTION)
                                     }
                                 } else {
                                     // IAMロール使用時
-                                    try {
-                                        executePulumiAction(params.ACTION)
-                                    } catch (Exception e) {
-                                        echo "警告: Pulumiアクション実行中にエラーが発生しました: ${e.message}"
-                                        env.PULUMI_ACTION_ERROR = 'true'
-                                    }
+                                    executePulumiActionSafely(params.ACTION)
                                 }
                             }
                         }
@@ -197,12 +193,19 @@ pipeline {
                                     processStackOutputs()
                                 }
                             }
-                            
-                            // Pulumiアクションでエラーがあった場合、最終的にUNSTABLEに設定
-                            if (env.PULUMI_ACTION_ERROR == 'true') {
-                                echo "Pulumiアクション実行中にエラーが発生したため、ビルドをUNSTABLEに設定します"
-                                currentBuild.result = 'UNSTABLE'
-                            }
+                        }
+                    }
+                }
+
+                /*
+                 * Pulumiアクションの実行結果を評価する
+                 * レポート生成・アーティファクト収集を先に行うため、判定は最後のステージで実施する。
+                 * when条件を付けないことで、preview を含む全アクションで必ず評価される。
+                 */
+                stage('Evaluate Pulumi Result') {
+                    steps {
+                        script {
+                            evaluatePulumiResult()
                         }
                     }
                 }
@@ -633,6 +636,38 @@ def generateDependencyGraph(actionType) {
             echo "警告: 空のグラフファイルが生成されました"
         fi
     """
+}
+
+/**
+ * Pulumiアクションを実行し、失敗しても後続のレポート生成を継続できるようにエラーを記録する
+ * 記録したエラーは 'Evaluate Pulumi Result' ステージで評価され、ビルドをFAILUREにする
+ * @param action 実行するアクション
+ */
+def executePulumiActionSafely(action) {
+    try {
+        executePulumiAction(action)
+    } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+        // ビルドの中断（Abort/タイムアウト）はエラーとして握り潰さず、そのまま伝播させる
+        throw e
+    } catch (Exception e) {
+        echo "❌ Pulumiアクション実行中にエラーが発生しました: ${e.message}"
+        echo "   レポート生成のため処理は継続しますが、ビルドは失敗として扱われます"
+        env.PULUMI_ACTION_ERROR = 'true'
+        env.PULUMI_ACTION_ERROR_MESSAGE = e.message ?: '詳細不明のエラー'
+    }
+}
+
+/**
+ * Pulumiアクションの実行結果を評価し、失敗していればビルドを失敗させる
+ */
+def evaluatePulumiResult() {
+    if (env.PULUMI_ACTION_ERROR == 'true') {
+        error """Pulumiアクション（${params.ACTION}）が失敗しました。
+エラー内容: ${env.PULUMI_ACTION_ERROR_MESSAGE}
+詳細はコンソールログおよびアーカイブされたPulumi実行ログを確認してください。"""
+    }
+
+    echo "✅ Pulumiアクション（${params.ACTION}）は正常に完了しました"
 }
 
 /**

--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
@@ -61,18 +61,19 @@ check_and_unlock_stack() {
 }
 
 # ロックエラーの場合に再試行する
+# 注意: errexit（set -e）は呼び出し側で無効化しておくこと。
+#       また、戻り値で結果を返すため、コマンド置換ではなく直接呼び出して $? を参照すること。
 retry_on_lock_error() {
     local action=$1
     local log_file=$2
     local exit_code=$3
 
-    if [ ${exit_code} -eq 255 ] && grep -q "currently locked" "$log_file"; then
+    if [ "${exit_code}" -eq 255 ] && grep -q "currently locked" "$log_file"; then
         echo "ロックエラーが検出されました。再度ロック解除を試みます..."
         pulumi cancel --yes || true
         sleep 10
 
         echo "再実行を試みます..."
-        set +e
         case "$action" in
             refresh)
                 pulumi refresh --yes --diff 2>&1 | tee "${log_file}.retry"
@@ -88,7 +89,6 @@ retry_on_lock_error() {
                 ;;
         esac
         local retry_exit_code=${PIPESTATUS[0]}
-        set -e
         return ${retry_exit_code}
     fi
     return ${exit_code}
@@ -108,7 +108,11 @@ case "$ACTION" in
         set -e
 
         # ロックエラーの場合は再試行
-        PULUMI_EXIT_CODE=$(retry_on_lock_error "preview" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.log" ${PULUMI_EXIT_CODE})
+        # 注意: コマンド置換で呼び出すと戻り値ではなく標準出力を取得してしまうため、直接呼び出して $? を使う
+        set +e
+        retry_on_lock_error "preview" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-preview.log" ${PULUMI_EXIT_CODE}
+        PULUMI_EXIT_CODE=$?
+        set -e
 
         if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
             echo "Pulumiプレビューが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
@@ -128,7 +132,11 @@ case "$ACTION" in
         set -e
 
         # ロックエラーの場合は再試行
-        PULUMI_EXIT_CODE=$(retry_on_lock_error "deploy" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.log" ${PULUMI_EXIT_CODE})
+        # 注意: コマンド置換で呼び出すと戻り値ではなく標準出力を取得してしまうため、直接呼び出して $? を使う
+        set +e
+        retry_on_lock_error "deploy" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-up.log" ${PULUMI_EXIT_CODE}
+        PULUMI_EXIT_CODE=$?
+        set -e
 
         if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
             echo "Pulumiデプロイが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
@@ -156,7 +164,11 @@ case "$ACTION" in
         set -e
 
         # ロックエラーの場合は再試行
-        PULUMI_EXIT_CODE=$(retry_on_lock_error "refresh" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-refresh.log" ${PULUMI_EXIT_CODE})
+        # 注意: コマンド置換で呼び出すと戻り値ではなく標準出力を取得してしまうため、直接呼び出して $? を使う
+        set +e
+        retry_on_lock_error "refresh" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-refresh.log" ${PULUMI_EXIT_CODE}
+        PULUMI_EXIT_CODE=$?
+        set -e
 
         if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
             echo "Pulumi refreshが失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"
@@ -184,7 +196,11 @@ case "$ACTION" in
         set -e
 
         # ロックエラーの場合は再試行
-        PULUMI_EXIT_CODE=$(retry_on_lock_error "destroy" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.log" ${PULUMI_EXIT_CODE})
+        # 注意: コマンド置換で呼び出すと戻り値ではなく標準出力を取得してしまうため、直接呼び出して $? を使う
+        set +e
+        retry_on_lock_error "destroy" "${WORKSPACE}/${ARTIFACTS_DIR}/pulumi-destroy.log" ${PULUMI_EXIT_CODE}
+        PULUMI_EXIT_CODE=$?
+        set -e
 
         if [ ${PULUMI_EXIT_CODE} -ne 0 ]; then
             echo "Pulumi削除が失敗しました（終了コード: ${PULUMI_EXIT_CODE}）"


### PR DESCRIPTION
Closes #587

## 概要

`pulumi-stack-action` パイプラインで Pulumi の実行が失敗しても Jenkins ジョブが SUCCESS になってしまう問題を修正しました。

## 原因

### 1. `env` の値が stage の `environment{}` に上書きされていた（今回の直接原因）

`PULUMI_ACTION_ERROR` を `Execute Pulumi Operations` ステージの `environment{}` ブロックで `'false'` と宣言していました。Declarative Pipeline ではこのブロック配下において `environment{}` の値が `env` への書き込みより優先されるため、catch 節で `env.PULUMI_ACTION_ERROR = 'true'` としても、判定側は常に `'false'` を読み取っていました。

### 2. `preview` では判定ステージ自体が実行されなかった

エラー判定が `Process Results` ステージ内にあり、その `when` が `deploy/destroy/refresh` に限定されていたため、`ACTION=preview` では判定が一切行われませんでした。

### 3. `execute-pulumi.sh` の終了コード取得が誤っていた

```bash
PULUMI_EXIT_CODE=$(retry_on_lock_error "preview" "${LOG}" ${PULUMI_EXIT_CODE})
```

コマンド置換のため、関数の**戻り値ではなく標準出力**を代入していました。この結果:

- ロックエラー時のリトライ処理が実質的に機能していなかった（リトライ出力も変数に吸い込まれてコンソールに出ない）
- 失敗時は `set -e` により代入行で中断し、`Pulumiプレビューが失敗しました（終了コード: N）` のメッセージが出力されなかった（今回のログでも出ていません）
- 成功時は毎回 `[: -ne: unary operator expected` が出力されていた

## 変更内容

### Jenkinsfile

| 変更 | 内容 |
| --- | --- |
| `PULUMI_ACTION_ERROR` のスコープ修正 | stage の `environment{}` から削除し、`Initialize and Validate` ステージでグローバルな `env` として初期化 |
| 判定ステージの分離 | `when` 条件を持たない `Evaluate Pulumi Result` ステージを新設し、`preview` を含む全アクションで必ず評価されるように変更 |
| 結果の変更 | Pulumi 失敗時を `UNSTABLE` → `FAILURE` に変更（エラー内容もメッセージに含める） |
| 中断の伝播 | `FlowInterruptedException`（Abort/タイムアウト）を握り潰さず再スロー |
| 重複整理 | 同一内容の try/catch 2箇所を `executePulumiActionSafely()` に集約 |

レポート生成・アーティファクト収集は従来どおり失敗時も実行され、その後に結果を評価します。

### execute-pulumi.sh

`retry_on_lock_error` を直接呼び出して `$?` で戻り値を受け取る形に修正（preview/deploy/refresh/destroy の4箇所）。あわせて関数側の `set -e` の付け外しを削除し、errexit の制御を呼び出し側に統一しました。

## 検証

`bash -n` による構文チェックに加え、同等ロジックを再現したスクリプトで以下を確認しました。

| シナリオ | 結果 |
| --- | --- |
| Pulumi 成功 (0) | exit 0、余計なエラー出力なし |
| Pulumi 失敗 (1) | メッセージ出力のうえ exit 1 |
| ロック以外の 255 | メッセージ出力のうえ exit 255 |
| ロックエラー → リトライ成功 | リトライ実行後 exit 0 |
| ロックエラー → リトライ失敗 | リトライ実行後 リトライの終了コードで exit |

## 反映手順

マージ後、シードジョブ `Admin_Jobs/job-creator` を実行してください（Jenkinsfile は `JENKINSFILE_BRANCH` 指定のため、`main` マージ時点で反映されます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
