### PR TITLE
[jenkins] fix: PRコメント生成のテンプレートパス解決を修正

### DIFF
--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/README.md
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/README.md
@@ -109,16 +109,36 @@ python pr_comment_generator.py \
 
 ### オプション
 
-- `--template-dir`: テンプレートディレクトリパス（デフォルト: `templates`）
+- `--template-dir`: テンプレートディレクトリパス（デフォルト: 自動解決）
 - `--save-prompts`: プロンプトと結果を保存
 - `--prompt-output-dir`: プロンプト保存ディレクトリ（デフォルト: `/prompts`）
 - `--log-level`: ログレベル（デフォルト: `INFO`）
+
+### プロンプトテンプレート
+
+プロンプトテンプレートは `pull-request-comment-builder/templates/` に配置します。
+
+| ファイル | 用途 |
+| --- | --- |
+| `base_template.md` | 全プロンプト共通のベース |
+| `chunk_analysis_extension.md` | チャンク分析時の追加指示 |
+| `summary_extension.md` | サマリー生成時の追加指示 |
+
+ディレクトリは以下の優先順位で解決されます。
+
+1. `--template-dir` オプション
+2. 環境変数 `PR_COMMENT_TEMPLATE_DIR`
+3. モジュールの位置から自動解決（`pull-request-comment-builder/templates/`）
+
+テンプレートが読み込めない場合、空のプロンプトがAPIに送信され変更内容と無関係なコメントが生成されるため、
+起動時にエラーとして処理を中断します。
 
 ### 環境変数
 
 - `OPENAI_API_KEY`: OpenAI APIキー（必須）
 - `OPENAI_MODEL_NAME`: 使用するモデル名（デフォルト: `gpt-4-turbo`）
 - `SAVE_PROMPTS`: プロンプト保存フラグ（デフォルト: `true`）
+- `PR_COMMENT_TEMPLATE_DIR`: テンプレートディレクトリ（`--template-dir` 未指定時に使用）
 
 ## テスト
 

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/cli.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/cli.py
@@ -19,6 +19,8 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument('--parallel', action='store_true', help='Use parallel processing for file fetching')
     parser.add_argument('--save-prompts', action='store_true', help='Save prompts and results to files')
     parser.add_argument('--prompt-output-dir', default='/prompts', help='Directory to save prompts and results')
+    parser.add_argument('--template-dir', default=None,
+                       help='Prompt template directory (default: auto-detected)')
     return parser
 
 
@@ -45,7 +47,7 @@ def main() -> None:
     log_level = getattr(logging, args.log_level)
 
     try:
-        generator = PRCommentGenerator(log_level=log_level)
+        generator = PRCommentGenerator(log_level=log_level, template_dir=args.template_dir)
         result = generator.generate_comment(args.pr_info, args.pr_diff)
 
         with open(args.output, 'w', encoding='utf-8') as f:

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/generator.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/generator.py
@@ -18,18 +18,22 @@ from .chunk_analyzer import ChunkAnalyzer
 class PRCommentGenerator:
     """改良版PRコメント生成を管理するクラス"""
 
-    def __init__(self, log_level=logging.INFO):
-        """OpenAIクライアントとGitHubクライアントを初期化"""
+    def __init__(self, log_level=logging.INFO, template_dir: Optional[str] = None):
+        """OpenAIクライアントとGitHubクライアントを初期化
+
+        Args:
+            log_level: ロギングレベル
+            template_dir: テンプレートディレクトリ（未指定時は自動解決）
+        """
         # ロギングの設定
         self._setup_logging(log_level)
-        
-        # 現在のディレクトリから1つ上の階層のtemplatesディレクトリを指定
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        template_dir = os.path.join(os.path.dirname(current_dir), 'templates')
-        
+
+        # テンプレートディレクトリを解決する
+        # 配置: pull-request-comment-builder/templates/
+        #       pull-request-comment-builder/src/pr_comment_generator/generator.py（このファイル）
+        # のため、このファイルから2階層上がテンプレートの親ディレクトリとなる
+        template_dir = os.path.abspath(template_dir) if template_dir else self._resolve_template_dir()
         self.logger.info(f"Template directory path: {template_dir}")
-        if not os.path.exists(template_dir):
-            self.logger.warning(f"Warning: Template directory not found at {template_dir}")
 
         # カスタム再試行設定（環境変数から取得可能）
         retry_config = {
@@ -40,6 +44,7 @@ class PRCommentGenerator:
 
         # 初期化の順序を変更
         self.prompt_manager = PromptTemplateManager(template_dir)
+        self._validate_templates(template_dir)
         self.openai_client = OpenAIClient(self.prompt_manager, retry_config=retry_config)
         self.chunk_analyzer = ChunkAnalyzer(self.openai_client, log_level=log_level)
         self.github_client = GitHubClient(auth_method="app", app_id=os.getenv('GITHUB_APP_ID'), token=os.getenv('GITHUB_ACCESS_TOKEN'))
@@ -48,6 +53,61 @@ class PRCommentGenerator:
         self.max_files_to_process = int(os.getenv('MAX_FILES_TO_PROCESS', '50'))  # 最大処理ファイル数
         self.max_file_size = int(os.getenv('MAX_FILE_SIZE', '10000'))  # 最大ファイルサイズ（行数）
         self.parallel_processing = os.getenv('PARALLEL_PROCESSING', 'false').lower() == 'true'
+
+    @staticmethod
+    def _resolve_template_dir() -> str:
+        """テンプレートディレクトリのパスを解決する
+
+        環境変数 PR_COMMENT_TEMPLATE_DIR が設定されている場合はそれを優先する。
+        設定されていない場合は、このモジュールの位置を基準に探索する。
+
+        Returns:
+            str: テンプレートディレクトリの絶対パス（見つからない場合は既定の候補パス）
+        """
+        env_dir = os.getenv('PR_COMMENT_TEMPLATE_DIR')
+        if env_dir:
+            return os.path.abspath(env_dir)
+
+        package_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # 候補1: pull-request-comment-builder/templates（正規の配置）
+        # 候補2: src/templates（過去のディレクトリ構成との互換用）
+        candidates = [
+            os.path.join(os.path.dirname(os.path.dirname(package_dir)), 'templates'),
+            os.path.join(os.path.dirname(package_dir), 'templates'),
+        ]
+
+        for candidate in candidates:
+            if os.path.isdir(candidate):
+                return candidate
+
+        # 見つからない場合は正規の配置を返し、後続の検証でエラーにする
+        return candidates[0]
+
+    def _validate_templates(self, template_dir: str) -> None:
+        """テンプレートが正しく読み込めているかを検証する
+
+        テンプレートが読み込めていない場合、プロンプトが空のままAPIに送信され、
+        無関係な内容のコメントが生成されてしまうため、ここで明示的に失敗させる。
+
+        Args:
+            template_dir: テンプレートディレクトリのパス
+
+        Raises:
+            RuntimeError: テンプレートが存在しない、または内容が空の場合
+        """
+        missing = [key for key, content in self.prompt_manager.templates.items() if not content]
+
+        if missing:
+            raise RuntimeError(
+                f"プロンプトテンプレートを読み込めませんでした: {', '.join(sorted(missing))}\n"
+                f"探索したディレクトリ: {template_dir}\n"
+                "テンプレートが読み込めない場合、空のプロンプトがAPIに送信され、"
+                "変更内容と無関係なコメントが生成されるため処理を中断します。\n"
+                "環境変数 PR_COMMENT_TEMPLATE_DIR でディレクトリを明示的に指定することもできます。"
+            )
+
+        self.logger.info(f"Loaded {len(self.prompt_manager.templates)} prompt templates from {template_dir}")
 
     def _setup_logging(self, log_level):
         """ロギングの設定"""
@@ -403,7 +463,11 @@ class PRCommentGenerator:
             # クラス属性として保存（他のメソッドから参照できるように）
             self.pr_info = pr_info
             self.skipped_file_names = skipped_file_names
-            
+
+            # OpenAIクライアントにもPR情報を渡す
+            # （プロンプト保存先のディレクトリ名に使用され、未設定だと pr_unknown になる）
+            self.openai_client.pr_info = pr_info
+
             # 読み込んだファイルの一覧を取得
             with open(pr_diff_path, 'r', encoding='utf-8') as f:
                 original_files = json.load(f)

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/integration/test_generator_flow.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/integration/test_generator_flow.py
@@ -65,6 +65,13 @@ def test_generate_comment_happy_path(monkeypatch, tmp_path):
     class FakePromptTemplateManager:
         def __init__(self, template_dir):
             self.template_dir = template_dir
+            # 実クラスと同様にテンプレートを保持する
+            # （空だとPRCommentGeneratorの検証でRuntimeErrorになる）
+            self.templates = {
+                "base": "base template",
+                "chunk": "chunk template",
+                "summary": "summary template",
+            }
 
     import pr_comment_generator.generator as gen
 

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_cli.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_cli.py
@@ -52,6 +52,7 @@ def test_parse_args_with_required_only(monkeypatch):
     assert args.parallel is False
     assert args.save_prompts is False
     assert args.log_level == "INFO"
+    assert args.template_dir is None
 
 
 def test_parse_args_with_all_options(monkeypatch):
@@ -71,6 +72,8 @@ def test_parse_args_with_all_options(monkeypatch):
             "DEBUG",
             "--prompt-output-dir",
             "/tmp/prompts",
+            "--template-dir",
+            "/tmp/templates",
         ]
     )
 
@@ -78,6 +81,7 @@ def test_parse_args_with_all_options(monkeypatch):
     assert args.parallel is True
     assert args.log_level == "DEBUG"
     assert args.prompt_output_dir == "/tmp/prompts"
+    assert args.template_dir == "/tmp/templates"
 
 
 def test_parse_args_missing_required(monkeypatch, capsys):
@@ -135,8 +139,9 @@ def test_main_writes_output_file(monkeypatch, tmp_path):
     cli = _import_cli_with_stub(monkeypatch)
 
     class FakeGenerator:
-        def __init__(self, log_level=logging.INFO):
+        def __init__(self, log_level=logging.INFO, template_dir=None):
             self.log_level = log_level
+            self.template_dir = template_dir
 
         def generate_comment(self, pr_info, pr_diff):
             return {
@@ -198,8 +203,9 @@ def test_main_writes_error_json_on_exception(monkeypatch, tmp_path):
     cli = _import_cli_with_stub(monkeypatch)
 
     class ExplodingGenerator:
-        def __init__(self, log_level=logging.INFO):
+        def __init__(self, log_level=logging.INFO, template_dir=None):
             self.log_level = log_level
+            self.template_dir = template_dir
 
         def generate_comment(self, pr_info, pr_diff):
             raise ValueError("missing input files")

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_generator.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_generator.py
@@ -1,11 +1,13 @@
 import json
 import logging
+import os
 import types
 
 import pytest
 
 from pr_comment_generator.generator import PRCommentGenerator
 from pr_comment_generator.models import FileChange, PRInfo
+from pr_comment_generator.prompt_manager import PromptTemplateManager
 
 
 def _make_generator():
@@ -283,3 +285,51 @@ def test_generate_comment_returns_message_when_no_changes(tmp_path):
     assert result["error"] == "No valid files to analyze"
     assert result["processed_file_count"] == 0
     assert result["file_count"] == 0
+
+
+class TestTemplateDirResolution:
+    """テンプレートディレクトリの解決と検証のテスト
+
+    テンプレートが読み込めないとプロンプトが空のままAPIに送信され、
+    変更内容と無関係なコメントが生成されるため、リグレッションを防ぐ。
+    """
+
+    def test_既定のテンプレートディレクトリが実在しテンプレートが揃っている(self):
+        template_dir = PRCommentGenerator._resolve_template_dir()
+
+        assert os.path.isdir(template_dir), (
+            f"テンプレートディレクトリが見つかりません: {template_dir}"
+        )
+
+        for filename in ('base_template.md', 'chunk_analysis_extension.md', 'summary_extension.md'):
+            path = os.path.join(template_dir, filename)
+            assert os.path.isfile(path), f"テンプレートが見つかりません: {path}"
+            assert os.path.getsize(path) > 0, f"テンプレートが空です: {path}"
+
+    def test_環境変数でテンプレートディレクトリを指定できる(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('PR_COMMENT_TEMPLATE_DIR', str(tmp_path))
+
+        assert PRCommentGenerator._resolve_template_dir() == os.path.abspath(str(tmp_path))
+
+    def test_既定のディレクトリで実際にテンプレートを読み込める(self):
+        manager = PromptTemplateManager(PRCommentGenerator._resolve_template_dir())
+
+        assert manager.templates['base'] != ""
+        assert manager.templates['chunk'] != ""
+        assert manager.templates['summary'] != ""
+
+    def test_テンプレートが空の場合はエラーになる(self, tmp_path):
+        gen = _make_generator()
+        gen.prompt_manager = PromptTemplateManager(str(tmp_path))
+
+        with pytest.raises(RuntimeError) as exc_info:
+            gen._validate_templates(str(tmp_path))
+
+        assert 'プロンプトテンプレートを読み込めませんでした' in str(exc_info.value)
+
+    def test_テンプレートが揃っていればエラーにならない(self):
+        gen = _make_generator()
+        template_dir = PRCommentGenerator._resolve_template_dir()
+        gen.prompt_manager = PromptTemplateManager(template_dir)
+
+        gen._validate_templates(template_dir)


### PR DESCRIPTION
Closes #589

## 概要

`pull-request-comment-builder` でプロンプトテンプレートが読み込めず、空のプロンプトが OpenAI API に送信されて変更内容と無関係なコメントが生成される問題を修正しました。

## 原因

テンプレートディレクトリのパス解決が誤っていました。

```python
current_dir = os.path.dirname(os.path.abspath(__file__))
template_dir = os.path.join(os.path.dirname(current_dir), 'templates')
```

コードが `src/pr_comment_generator/` パッケージに移動した際に、この「1つ上の階層」というロジックが更新されないまま残っていました。

| | パス |
| --- | --- |
| 解決結果 | `src/templates`（存在しない） |
| 実際の配置 | `pull-request-comment-builder/templates` |

その結果、3つのテンプレートがすべて空文字列となり、ユーザープロンプトが空のまま送信されていました。ログの `Prompt: 30` トークン（システムメッセージのみ）と、返ってきた挨拶文がその証拠です。

さらに、テンプレートが読み込めなくても警告のみで処理が継続されるため、無意味なコメントが PR に投稿されたうえでジョブは成功扱いになっていました。

## 変更内容

| 変更 | 内容 |
| --- | --- |
| パス解決の修正 | `_resolve_template_dir()` に分離し、正しい階層（パッケージから2階層上）を参照。旧構成の `src/templates` もフォールバックとして探索 |
| 失敗時の中断 | テンプレートが空の場合は `RuntimeError` を送出。CLI が終了コード1で終了し、Jenkins ジョブも失敗する |
| `--template-dir` の実装 | README に記載済みだが未実装だったオプションを実装。環境変数 `PR_COMMENT_TEMPLATE_DIR` にも対応 |
| `pr_unknown` の修正 | `OpenAIClient` に PR 情報を渡していなかったため、プロンプト保存先が `pr_unknown_<timestamp>` になっていた |
| README 更新 | テンプレートの配置場所と解決優先順位を追記 |

## 検証

```
124 passed
```

追加したリグレッションテスト（`tests/unit/test_generator.py`）:

- 既定のテンプレートディレクトリが実在し、3ファイルが空でないこと
- 既定のディレクトリから実際にテンプレートを読み込めること
- 環境変数でディレクトリを指定できること
- テンプレートが空の場合に `RuntimeError` になること

あわせて、テンプレート適用後のプロンプトが実際に生成されること（チャンク分析用 1469 文字 / サマリー用 1292 文字）を確認しました。修正前はいずれも空文字列です。

既存テストは常に `template_dir` を明示注入していたため、実パス解決が一度もテストされておらず、この不具合を検知できていませんでした。今回のテストはその隙間を埋めます。

なお、テスト内のフェイククラス3箇所を実クラスのインターフェース（`templates` 属性、`template_dir` 引数）に合わせて更新しています。

## 補足

Jenkinsfile 自体の変更は不要でした。CLI が終了コード1を返すようになったことで、`OpenAIによる分析` ステージの既存のエラーハンドリングがそのまま機能します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
