### PR TITLE
[jenkins] update: PRコメント生成のモデルをgpt-5.6-terraに更新

### DIFF
--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/Jenkinsfile
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/Jenkinsfile
@@ -15,8 +15,10 @@ pipeline {
     
     environment {
         // OpenAI API設定
+        // 注意: 変数名は src/pr_comment_generator/openai_client.py が参照する
+        //       OPENAI_MODEL_NAME と一致させること
         OPENAI_API_KEY = credentials('openai-api-key')
-        OPENAI_MODEL = "gpt-4.1"
+        OPENAI_MODEL_NAME = "gpt-5.6-terra"
         
         // 作業ディレクトリ構造（WORKSPACEからの相対パス）
         WORKSPACE_DIR = "pr-workspace"

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/README.md
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/README.md
@@ -136,9 +136,34 @@ python pr_comment_generator.py \
 ### 環境変数
 
 - `OPENAI_API_KEY`: OpenAI APIキー（必須）
-- `OPENAI_MODEL_NAME`: 使用するモデル名（デフォルト: `gpt-4-turbo`）
+- `OPENAI_MODEL_NAME`: 使用するモデル名（デフォルト: `gpt-5.6-terra`）
+- `OPENAI_REASONING_EFFORT`: reasoningモデルの推論強度（未指定時は送信しない）
 - `SAVE_PROMPTS`: プロンプト保存フラグ（デフォルト: `true`）
 - `PR_COMMENT_TEMPLATE_DIR`: テンプレートディレクトリ（`--template-dir` 未指定時に使用）
+
+### 使用モデル
+
+デフォルトは `gpt-5.6-terra`（能力とコストのバランス型）です。
+変更する場合は Jenkinsfile の `OPENAI_MODEL_NAME` を設定してください。
+
+| モデル | 用途 |
+| --- | --- |
+| `gpt-5.6-sol` | 最も高精度。複雑な変更の分析向け |
+| `gpt-5.6-terra` | バランス型（デフォルト） |
+| `gpt-5.6-luna` | 低コスト・高速。大量処理向け |
+
+#### reasoningモデルとレガシーモデルの違い
+
+`gpt-5` 系および `o` 系は reasoning モデルであり、リクエストパラメータの扱いが異なります。
+`OpenAIClient._build_request_params()` がモデルIDから判別して自動的に切り替えます。
+
+| | reasoningモデル | レガシーモデル（`gpt-4.1` 等） |
+| --- | --- | --- |
+| 出力トークン指定 | `max_completion_tokens` | `max_tokens` |
+| `temperature` / `top_p` | 送信しない | `0.0` / `0.1` |
+| `frequency_penalty` / `presence_penalty` | 送信しない | `0.0` |
+
+reasoningモデルでは推論トークンも出力枠を消費するため、指定値を4倍（最低4000）に拡大して送信します。
 
 ## テスト
 

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/openai_client.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/src/pr_comment_generator/openai_client.py
@@ -26,7 +26,21 @@ class OpenAIClient:
     MAX_TOKENS_PER_REQUEST = 16000  # GPT-4の一般的な入力制限の安全側
     MAX_PATCH_TOKENS = 2000  # パッチに割り当てる最大トークン
     MAX_CONTENT_TOKENS = 3000  # ファイル内容に割り当てる最大トークン
-    
+
+    # 既定のモデル
+    DEFAULT_MODEL_NAME = 'gpt-5.6-terra'
+
+    # reasoningモデルの判定に使用するモデルID接頭辞
+    # これらのモデルはサンプリングパラメータに制約があり、
+    # max_tokens ではなく max_completion_tokens を使用する
+    REASONING_MODEL_PREFIXES = ('gpt-5', 'o1', 'o3', 'o4')
+
+    # reasoningモデルでは推論トークンも出力トークン枠を消費するため、
+    # 従来のmax_tokensをそのまま使うと本文が出力されずに打ち切られる可能性がある
+    REASONING_TOKEN_MULTIPLIER = 4
+    REASONING_MIN_COMPLETION_TOKENS = 4000
+
+
     def __init__(self, prompt_manager, retry_config=None, log_level=logging.INFO):
         """
         環境変数から認証情報を取得してクライアントを初期化
@@ -41,7 +55,7 @@ class OpenAIClient:
         
         # 環境変数から認証情報を取得
         api_key = os.getenv('OPENAI_API_KEY')
-        model_name = os.getenv('OPENAI_MODEL_NAME', 'gpt-4.1')  # デフォルトモデル名
+        model_name = os.getenv('OPENAI_MODEL_NAME', self.DEFAULT_MODEL_NAME)
 
         if not api_key:
             raise ValueError("Missing required environment variable: OPENAI_API_KEY")
@@ -214,44 +228,100 @@ class OpenAIClient:
             for msg in messages
         ])
     
+    def _is_reasoning_model(self) -> bool:
+        """現在のモデルがreasoningモデルかどうかを判定する
+
+        Returns:
+            bool: reasoningモデルの場合True
+        """
+        return self.model.lower().startswith(self.REASONING_MODEL_PREFIXES)
+
+    def _build_request_params(self, messages: List[Dict[str, str]], max_tokens: int) -> Dict[str, Any]:
+        """モデルの種類に応じたAPIリクエストパラメータを組み立てる
+
+        reasoningモデル（gpt-5系、o系）は temperature / top_p / penalty 系の
+        サンプリングパラメータをサポートせず、max_tokens ではなく
+        max_completion_tokens を使用する。従来のパラメータをそのまま渡すと
+        リクエストが拒否されるため、モデルごとに切り替える。
+
+        Args:
+            messages: 送信するメッセージリスト
+            max_tokens: 生成する最大トークン数
+
+        Returns:
+            Dict[str, Any]: chat.completions.create に渡すパラメータ
+        """
+        params: Dict[str, Any] = {
+            'model': self.model,
+            'messages': messages,
+            'response_format': {"type": "text"},
+        }
+
+        if self._is_reasoning_model():
+            # 推論トークンも枠を消費するため、余裕を持たせる
+            params['max_completion_tokens'] = max(
+                max_tokens * self.REASONING_TOKEN_MULTIPLIER,
+                self.REASONING_MIN_COMPLETION_TOKENS
+            )
+
+            # reasoning_effort は明示指定された場合のみ送信する
+            # （モデルによってサポート状況が異なるため、既定では送らない）
+            reasoning_effort = os.getenv('OPENAI_REASONING_EFFORT')
+            if reasoning_effort:
+                params['reasoning_effort'] = reasoning_effort
+        else:
+            params['max_tokens'] = max_tokens
+            params['temperature'] = 0.0
+            params['top_p'] = 0.1
+            params['frequency_penalty'] = 0.0
+            params['presence_penalty'] = 0.0
+
+        return params
+
     def _make_api_request(self, messages: List[Dict[str, str]], max_tokens: int) -> Any:
         """OpenAI APIリクエストを実行する"""
+        params = self._build_request_params(messages, max_tokens)
+
         # リクエスト情報をログ出力
         self.logger.info(f"Making API request to model: {self.model}")
         self.logger.info(f"Request parameters:")
-        self.logger.info(f"  - Max tokens: {max_tokens}")
-        self.logger.info(f"  - Temperature: 0.0")
-        self.logger.info(f"  - Top-p: 0.1")
+        self.logger.info(f"  - Reasoning model: {self._is_reasoning_model()}")
+        for key in ('max_tokens', 'max_completion_tokens', 'temperature', 'top_p', 'reasoning_effort'):
+            if key in params:
+                self.logger.info(f"  - {key}: {params[key]}")
         self.logger.info(f"  - Messages count: {len(messages)}")
-        
+
         # メッセージの概要をログ出力（長すぎる場合は省略）
         for i, msg in enumerate(messages):
             role = msg['role']
             content_preview = msg['content'][:100] + "..." if len(msg['content']) > 100 else msg['content']
             self.logger.info(f"  - Message {i+1} [{role}]: {content_preview}")
-        
+
         # API呼び出し
         self.logger.info("Sending request to OpenAI API...")
-        
-        return self.client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            temperature=0.0,
-            max_tokens=max_tokens,
-            top_p=0.1,
-            frequency_penalty=0.0,
-            presence_penalty=0.0,
-            response_format={"type": "text"}
-        )
+
+        return self.client.chat.completions.create(**params)
     
     def _process_successful_response(self, response: Any, prompt_content: str) -> str:
         """成功したレスポンスを処理する"""
         # トークン使用量を記録
         self._record_token_usage(response.usage)
-        
+
         # レスポンス内容を取得
-        generated_content = response.choices[0].message.content.strip()
-        
+        choice = response.choices[0]
+        content = getattr(choice.message, 'content', None)
+
+        # reasoningモデルでは推論トークンが出力枠を使い切ると本文が空になることがある
+        if not content:
+            finish_reason = getattr(choice, 'finish_reason', 'unknown')
+            raise RuntimeError(
+                f"モデル {self.model} から空の応答が返されました（finish_reason: {finish_reason}）。"
+                "reasoningモデルで出力トークンが不足している可能性があります。"
+            )
+
+        generated_content = content.strip()
+
+
         # ログ出力
         self._log_response_info(response, generated_content)
         

--- a/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_openai_client.py
+++ b/jenkins/jobs/pipeline/docs-generator/pull-request-comment-builder/tests/unit/test_openai_client.py
@@ -254,3 +254,97 @@ def test_save_prompt_and_result_skips_when_disabled(monkeypatch, tmp_path):
     client._save_prompt_and_result("prompt text", "result text", chunk_index=0, phase="chunk")
 
     assert not output_dir.exists()
+
+
+class TestRequestParameters:
+    """モデルの種類に応じたリクエストパラメータ組み立てのテスト
+
+    reasoningモデルにレガシー用のサンプリングパラメータを渡すと
+    リクエストが拒否されるため、切り替えが正しく行われることを保証する。
+    """
+
+    def test_既定のモデルはgpt_5_6_terra(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OPENAI_MODEL_NAME", raising=False)
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        assert client.model == "gpt-5.6-terra"
+        assert client._is_reasoning_model() is True
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna", "gpt-5", "o3-mini"])
+    def test_reasoningモデルと判定される(self, monkeypatch, tmp_path, model):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", model)
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        assert client._is_reasoning_model() is True
+
+    @pytest.mark.parametrize("model", ["gpt-4.1", "gpt-4.1-mini", "gpt-4o"])
+    def test_レガシーモデルと判定される(self, monkeypatch, tmp_path, model):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", model)
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        assert client._is_reasoning_model() is False
+
+    def test_reasoningモデルはサンプリングパラメータを送らない(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-5.6-terra")
+        monkeypatch.delenv("OPENAI_REASONING_EFFORT", raising=False)
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        params = client._build_request_params([{"role": "user", "content": "hi"}], 2000)
+
+        assert "max_tokens" not in params
+        assert "temperature" not in params
+        assert "top_p" not in params
+        assert "frequency_penalty" not in params
+        assert "presence_penalty" not in params
+        assert "reasoning_effort" not in params
+        assert params["max_completion_tokens"] == 8000
+        assert params["model"] == "gpt-5.6-terra"
+
+    def test_reasoningモデルの出力トークンには下限がある(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-5.6-terra")
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        # タイトル生成時の max_tokens=100 でも推論トークン分の余裕を確保する
+        params = client._build_request_params([{"role": "user", "content": "hi"}], 100)
+
+        assert params["max_completion_tokens"] == 4000
+
+    def test_reasoning_effortは明示指定時のみ送信される(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-5.6-terra")
+        monkeypatch.setenv("OPENAI_REASONING_EFFORT", "low")
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        params = client._build_request_params([{"role": "user", "content": "hi"}], 2000)
+
+        assert params["reasoning_effort"] == "low"
+
+    def test_レガシーモデルは従来のパラメータを送る(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-4.1")
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        params = client._build_request_params([{"role": "user", "content": "hi"}], 2000)
+
+        assert params["max_tokens"] == 2000
+        assert "max_completion_tokens" not in params
+        assert params["temperature"] == 0.0
+        assert params["top_p"] == 0.1
+        assert params["frequency_penalty"] == 0.0
+        assert params["presence_penalty"] == 0.0
+
+    def test_空応答はエラーになる(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-5.6-terra")
+        _, client = _create_openai_client(monkeypatch, tmp_path)
+
+        response = types.SimpleNamespace(
+            choices=[types.SimpleNamespace(
+                message=types.SimpleNamespace(content=None),
+                finish_reason="length",
+            )],
+            usage=types.SimpleNamespace(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            client._process_successful_response(response, "prompt")
+
+        assert "空の応答" in str(exc_info.value)
+        assert "length" in str(exc_info.value)


### PR DESCRIPTION
Closes #591

> **マージ順序**: このPRは #590 のブランチをベースにしています。**#590 を先にマージ**してください。マージ後、このPRのベースは自動的に `main` に切り替わります。

## 概要

`pull-request-comment-builder` の OpenAI モデルを `gpt-4.1` から現行世代の `gpt-5.6-terra` に更新しました。あわせて、モデル切り替えを妨げていた2つの不具合を修正しています。

## モデル選定

現行ラインナップは GPT-5.6（3ティア）。PRコメント生成は「相応の読解力は要るが最上位までは不要」な用途のため、バランス型の Terra を採用しました。

| モデルID | 位置づけ | 入力/1M | 出力/1M | キャッシュ入力/1M |
| --- | --- | --- | --- | --- |
| `gpt-5.6-sol` | フラッグシップ | $5 | $30 | $0.50 |
| **`gpt-5.6-terra`** | **バランス型（採用）** | **$2.50** | **$15** | **$0.25** |
| `gpt-5.6-luna` | 低コスト・高速 | $1 | $6 | $0.10 |

`gpt-4.1` は廃止予定には入っていませんが、現行の料金ページからは外れており実質レガシー扱いです。

## 修正した不具合

### 1. 環境変数名の不一致（モデル設定が反映されなかった）

```groovy
OPENAI_MODEL = "gpt-4.1"          // Jenkinsfile が設定
```
```python
os.getenv('OPENAI_MODEL_NAME', ...)  # コードが参照
```

`OPENAI_MODEL` を読む箇所はリポジトリ内に存在せず、**Jenkinsfile でモデルを変更しても反映されない**状態でした。両者の既定値がたまたま `gpt-4.1` で一致していたため顕在化していませんでした。Jenkinsfile 側を `OPENAI_MODEL_NAME` に統一しています。

### 2. reasoningモデルに非互換なリクエストパラメータ

従来は `temperature` / `top_p` / `max_tokens` / penalty 系を常に送信していました。gpt-5系はreasoningモデルでこれらに制約があるため、モデル名を差し替えるだけではリクエストが通りません。

`_build_request_params()` を追加し、モデルIDから判別して切り替えます。

| | reasoningモデル | レガシーモデル |
| --- | --- | --- |
| 出力トークン指定 | `max_completion_tokens` | `max_tokens` |
| `temperature` / `top_p` | 送信しない | `0.0` / `0.1` |
| penalty 系 | 送信しない | `0.0` |

reasoningモデルでは推論トークンも出力枠を消費するため、`max_completion_tokens` は指定値の4倍（最低4000）に拡大して送信します。従来の `max_tokens=2000`、タイトル生成時の `100` をそのまま使うと、推論で枠を使い切って本文が空になる可能性があるためです。

## その他の変更

- 推論トークンで出力枠を使い切った場合の空応答を検出し、`finish_reason` 付きでエラーにする（従来は `None.strip()` で AttributeError になっていました）
- `reasoning_effort` は `OPENAI_REASONING_EFFORT` 指定時のみ送信（モデルによるサポート差を避けるため既定では送りません）
- 実際に送信するパラメータをログ出力（従来は `Temperature: 0.0` 等を固定文字列で出力しており、実態と乖離する余地がありました）
- README のモデル関連記述を更新。既定値を `gpt-4-turbo` と誤記していた箇所も修正（`gpt-4-turbo` 自体が2026年10月23日シャットダウン予定）

## 検証

```
138 passed
```

追加したテスト（`tests/unit/test_openai_client.py`）: モデル判別（gpt-5.6各ティア / gpt-5 / o3-mini / gpt-4.1 / gpt-4o）、reasoningモデルでサンプリングパラメータを送らないこと、出力トークンの下限、`reasoning_effort` の条件付き送信、レガシーモデルの従来動作、空応答時のエラー。

スタブを使って `chat.completions.create` の実引数も確認しました。

| モデル | 送信キー |
| --- | --- |
| `gpt-5.6-terra` | `max_completion_tokens`(8000), `model`, `messages`, `response_format` |
| `gpt-4.1` | `max_tokens`(2000), `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `model`, `messages`, `response_format` |

**実APIでの疎通は未検証です。** reasoningモデルのパラメータ制約は公式ドキュメントのモデルページに明記がなかったため、実装は既知の仕様に基づいています。マージ後、実PRで1回実行して確認をお願いします。問題があれば `OPENAI_MODEL_NAME` を `gpt-4.1` に戻すだけで従来動作に復帰します（レガシー側の分岐は残してあります）。

## 対象外

`MAX_TOKENS_PER_REQUEST = 16000` は GPT-4 前提の保守的な入力上限で、gpt-5.6 の 1,050,000 コンテキストに対して過度に小さく、大きなPRでは差分が積極的に切り詰められています。緩和すれば分析品質は上がりますが1回あたりのコストが増えるため、判断が必要と考え今回は据え置きました。必要であれば別途対応します。

他の docs-generator パイプライン（`auto-insert-doxygen-comment`、`diagram-generator`、`mermaid-generator`、`technical-docs-writer`）も `gpt-4.1` 系のままですが、今回のスコープ外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
