### PR TITLE
[jenkins] fix: Pulumiのスタックロックエラーを自動リカバリーするよう修正

### DIFF
--- a/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
+++ b/jenkins/jobs/pipeline/infrastructure/pulumi-stack-action/scripts/execute-pulumi.sh
@@ -33,30 +33,54 @@ source "$SCRIPT_DIR/setup-aws-credentials.sh"
 # 共通関数
 # =====================================================
 
-# スタックロックを確認し、必要に応じて解除する
+# ログにスタックロックのエラーが含まれるかを判定する
+# Pulumiのロックエラーメッセージ例:
+#   error: the stack is currently locked by 1 lock(s). Either wait for the other
+#   process(es) to end or delete the lock file with `pulumi cancel`.
+contains_lock_error() {
+    local target=$1
+
+    if [ ! -f "$target" ]; then
+        return 1
+    fi
+
+    grep -qE "currently locked|delete the lock file" "$target"
+}
+
+# スタックのロックを解除する
+unlock_stack() {
+    echo "ロックを解除します（pulumi cancel）..."
+
+    if pulumi cancel --yes 2>&1; then
+        echo "✅ ロック解除に成功しました"
+        sleep 5
+        return 0
+    fi
+
+    echo "⚠️ ロック解除に失敗しました"
+    sleep 3
+    return 1
+}
+
+# スタックロックを事前確認し、検出された場合は解除する
+# 注意: pulumi stack はロックを取得しないため、ここでロックを検出できない場合がある。
+#       実際のロック検出は各コマンド実行後の retry_on_lock_error が担う。
 check_and_unlock_stack() {
-    echo "スタックロックの確認..."
+    echo "スタックロックの事前確認..."
 
-    # スタック状態の取得
+    # スタック状態の取得（失敗してもここでは中断しない）
     local stack_status
-    stack_status=$(pulumi stack 2>&1)
+    stack_status=$(pulumi stack 2>&1 || true)
 
-    if echo "$stack_status" | grep -q "currently locked"; then
+    if echo "$stack_status" | grep -qE "currently locked|delete the lock file"; then
         echo "警告: スタックがロックされています。"
 
         # ロック情報の詳細を表示
         echo "$stack_status" | grep -E "(locked|pid|created by)" || true
 
-        echo "ロックを解除します..."
-        if pulumi cancel --yes 2>&1; then
-            echo "✅ ロック解除に成功しました"
-            sleep 5
-        else
-            echo "⚠️ ロック解除に失敗しました。続行を試みます..."
-            sleep 3
-        fi
+        unlock_stack || echo "続行を試みます..."
     else
-        echo "✅ スタックはロックされていません"
+        echo "事前確認ではロックを検出しませんでした（実行時に検出された場合は自動で解除を試みます）"
     fi
 }
 
@@ -68,9 +92,15 @@ retry_on_lock_error() {
     local log_file=$2
     local exit_code=$3
 
-    if [ "${exit_code}" -eq 255 ] && grep -q "currently locked" "$log_file"; then
-        echo "ロックエラーが検出されました。再度ロック解除を試みます..."
-        pulumi cancel --yes || true
+    # ロックエラー時の終了コードはPulumiのバージョンや実行経路により異なる（1 や 255 など）ため、
+    # 終了コードでは判定せず、ログの内容でロックエラーを判定する
+    if [ "${exit_code}" -ne 0 ] && contains_lock_error "$log_file"; then
+        echo "========================================"
+        echo "ロックエラーを検出しました（終了コード: ${exit_code}）"
+        grep -E "created by|pid|locks/" "$log_file" || true
+        echo "========================================"
+
+        unlock_stack || true
         sleep 10
 
         echo "再実行を試みます..."
@@ -89,6 +119,18 @@ retry_on_lock_error() {
                 ;;
         esac
         local retry_exit_code=${PIPESTATUS[0]}
+
+        # 再実行でもロックが解消しない場合は、手動対応が必要なため案内を出す
+        if [ ${retry_exit_code} -ne 0 ] && contains_lock_error "${log_file}.retry"; then
+            echo "========================================"
+            echo "⚠️ 再実行後もロックが解消されませんでした"
+            echo "他のプロセスが実行中の可能性があります。以下を確認してください:"
+            echo "  1. 同じスタックを操作している他のJenkinsジョブが実行中でないか"
+            echo "  2. 上記のロック情報（作成者・PID・作成時刻）"
+            echo "実行中のプロセスがない場合は、手動で 'pulumi cancel' を実行してください"
+            echo "========================================"
+        fi
+
         return ${retry_exit_code}
     fi
     return ${exit_code}


### PR DESCRIPTION
Closes #593

> **マージ順序**: このPRは #588 のブランチをベースにしています。**#588 を先にマージ**してください。マージ後、このPRのベースは自動的に `main` に切り替わります。

## 概要

スタックロックエラー発生時に自動リカバリー（`pulumi cancel` + 再実行）が機能せず、そのままジョブが失敗する問題を修正しました。

修正箇所は Jenkinsfile ではなく、同ジョブが呼び出す `scripts/execute-pulumi.sh` です。ロック処理はすべてこちらに実装されています。

## 原因

### 1. 再試行の判定条件が終了コード255に限定されていた（直接原因）

```bash
if [ "${exit_code}" -eq 255 ] && grep -q "currently locked" "$log_file"; then
```

今回のロックエラーの終了コードは **1** だったため条件を満たさず、リカバリー処理が一度も走りませんでした。ログでも `pulumi cancel` の実行や再試行の形跡がないまま終了しています。

ロックエラー時の終了コードは Pulumi のバージョンや実行経路により異なるため、終了コードでの判定自体をやめ、ログ内容で判定するようにしました。

### 2. 事前チェックがロックを検出できていなかった

```
スタックロックの確認...
✅ スタックはロックされていません     ← 実際にはロックされていた
```

`check_and_unlock_stack()` は `pulumi stack` の出力を見ていますが、**`pulumi stack` はロックを取得しない**ため、ロックが存在しても検出できません。表示が実態と食い違い、誤解を招く状態でした。

事前チェックはベストエフォートである旨を明示し、実際の検出は各コマンド実行後の `retry_on_lock_error` に委ねる構成にしました。

### 3. 事前チェックが `set -e` で中断する可能性

`stack_status=$(pulumi stack 2>&1)` は、`pulumi stack` が失敗するとスクリプト全体を中断させます。`|| true` を追加しました。

## 変更内容

| 変更 | 内容 |
| --- | --- |
| 判定条件 | `exit_code -eq 255` → `exit_code -ne 0` かつログにロックエラーが含まれる場合 |
| 共通化 | ロック判定を `contains_lock_error()`、解除を `unlock_stack()` に集約 |
| 検出メッセージ | ロック検出時に作成者・PID・作成時刻・ロックファイルパスを出力 |
| 事前チェック | 表示を実態に即した文言に変更し、`|| true` で中断を防止 |
| 再試行後の案内 | 再実行でもロックが解消しない場合、確認事項と手動 `pulumi cancel` の案内を出力 |

判定パターンは `currently locked|delete the lock file` としています。

## 検証

実ログのメッセージをそのまま使い、関数を実スクリプトから抽出してスタブ実行で確認しました。

| シナリオ | 結果 |
| --- | --- |
| 今回の再現（exit 1 + ロック）→ リトライ成功 | ロック情報を出力 → cancel → 再実行 → exit 0 |
| exit 1 + ロック → リトライも失敗 | 手動対応の案内を出力 → リトライの終了コードで終了 |
| ロック以外の失敗 | リトライせず元の終了コードを返す |
| 成功時 | 何もせず exit 0 |

修正前は1つ目のシナリオでリトライが発生せず、そのまま exit 1 になっていました。

**実環境での動作確認は未実施です。** ロック状態を意図的に作る必要があるため、マージ後に実際のロック発生時の挙動をご確認ください。

## 補足

このジョブには `disableConcurrentBuilds()` が設定されているため、同一ジョブの同時実行によるロックは発生しません。今回のロックは別ホスト（`ip-10-0-1-153`、pid 4234）で作成されており、中断されたビルドが残した stale lock と考えられます。この用途では自動 `pulumi cancel` は妥当ですが、万一他ジョブが同一スタックを実行中だった場合に備え、再試行後も解消しない場合は自動解除を繰り返さず手動確認を促す形にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
