### PR TITLE
[pulumi] lambda-api-gatewayの統合タイムアウトを120秒に延長

### DIFF
--- a/pulumi/lambda-api-gateway/index.ts
+++ b/pulumi/lambda-api-gateway/index.ts
@@ -119,6 +119,9 @@ const apiIntegration = new aws.apigateway.Integration("api-integration", {
     httpMethod: apiMethod.httpMethod,
     type: "AWS_PROXY",
     integrationHttpMethod: "POST",
+    // 生成系API（物語・画像）は40〜60秒かかるため、デフォルト29秒では504になる。
+    // Lambda側の応答上限（WALLCLOCK 85秒）+ 余裕で120秒とする
+    timeoutMilliseconds: 120000,
     uri: pulumi.interpolate`arn:aws:apigateway:${aws.config.region}:lambda:path/2015-03-31/functions/${lambdaFunctionArn}/invocations`,
 }, {
     dependsOn: [lambdaPermission],
@@ -150,6 +153,9 @@ const proxyIntegration = new aws.apigateway.Integration("proxy-integration", {
     httpMethod: proxyMethod.httpMethod,
     type: "AWS_PROXY",
     integrationHttpMethod: "POST",
+    // 生成系API（物語・画像）は40〜60秒かかるため、デフォルト29秒では504になる。
+    // Lambda側の応答上限（WALLCLOCK 85秒）+ 余裕で120秒とする
+    timeoutMilliseconds: 120000,
     uri: pulumi.interpolate`arn:aws:apigateway:${aws.config.region}:lambda:path/2015-03-31/functions/${lambdaFunctionArn}/invocations`,
 }, {
     dependsOn: [lambdaPermission],


### PR DESCRIPTION
Closes #597

## 変更内容

`pulumi/lambda-api-gateway/index.ts` の `/api` と `/api/{proxy+}` の Lambda 統合に `timeoutMilliseconds: 120000` を追加（healthはデフォルトのまま）。

## 背景

reflection-cloud-api の物語・画像生成は処理に40〜60秒かかるが、統合タイムアウトがデフォルト29秒のままのため断続的に504が発生していた（実測: prod `/api/{proxy+}` = 29000ms）。Lambda側の応答設計上限（WALLCLOCK 85秒）+ 余裕で120秒とする。

## デプロイ時の注意

- dev / prod 両スタックへの適用が必要
- アカウントの Service Quotas（API Gateway: Maximum integration timeout）が 29000ms のままの場合、`pulumi up` が弾かれる可能性がある。その場合は先に Service Quotas の引き上げ申請（L-E5AE38E3 相当）を行うこと


## 追加: Lambda関数タイムアウトも120秒に（同PRに含む）

調査の過程で、Lambda関数自体のタイムアウトが dev=30秒 / prod=60秒 と、アプリ側の応答設計上限（WALLCLOCK 85秒）より短いことが判明。Gateway だけ延ばしても 60〜85秒の生成は Lambda 側で強制終了されるため、`lambda-ssm-init` の `lambdaTimeout` を両環境 120 に変更。

タイムアウトの階層: アプリ予算 (85s) < Lambda (120s) ≦ API Gateway (120s)

### デプロイ順の注意
`lambda-ssm-init`（SSM値の更新）→ `lambda-functions`（SSMを読んでLambdaに反映）→ `lambda-api-gateway` の順で適用が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSqkmcDNjxSDjU4UL25HTW