### PR TITLE
[pulumi] fix: lambda-ssm-initのtsconfigにmoduleResolutionを明示

### DIFF
--- a/pulumi/lambda-ssm-init/tsconfig.json
+++ b/pulumi/lambda-ssm-init/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
+    "moduleResolution": "node",
     "lib": ["ES2020"],
     "outDir": "./",
     "rootDir": "./",


### PR DESCRIPTION
依存が固定されていない環境で新しいTypeScript系が解決されると、
moduleResolution未指定の解釈が変わり TS5110 で preview が失敗する。 他スタック（lambda-functions等）と同じ moduleResolution: node を明示する。