### PR TITLE
[pulumi] add: lambda-ssm-initにElevenLabs用SSMパラメータを追加

### DIFF
--- a/pulumi/lambda-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.dev.yaml
@@ -30,3 +30,6 @@ config:
   lambda-ssm-init:openaiApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:openaiSpeedModel: "gpt-5.6-luna"
   lambda-ssm-init:openaiQualityModel: "gpt-5.6-terra"
+  # AI API設定（ElevenLabs API・物語朗読用TTS）
+  lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
+  lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"

--- a/pulumi/lambda-ssm-init/Pulumi.prod.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.prod.yaml
@@ -30,3 +30,6 @@ config:
   lambda-ssm-init:openaiApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:openaiSpeedModel: "gpt-5.6-luna"
   lambda-ssm-init:openaiQualityModel: "gpt-5.6-terra"
+  # AI API設定（ElevenLabs API・物語朗読用TTS）
+  lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
+  lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"

--- a/pulumi/lambda-ssm-init/components/applicationParameters.ts
+++ b/pulumi/lambda-ssm-init/components/applicationParameters.ts
@@ -19,6 +19,8 @@ interface AIApiConfig {
     openaiApiKey?: string;
     openaiSpeedModel?: string;
     openaiQualityModel?: string;
+    elevenLabsApiKey?: string;
+    elevenLabsVoiceId?: string;
 }
 
 /**
@@ -95,6 +97,25 @@ export function createApplicationParameters(
             value: config.aiApi.openaiQualityModel,
             type: "String",
             description: "高品質処理用のOpenAIモデル名",
+        });
+    }
+
+    // ElevenLabs API設定（物語朗読用TTS）
+    if (config.aiApi.elevenLabsApiKey !== undefined) {
+        parameters.elevenLabsApiKey = ssmHelper.createParameter('/app/settings/elevenlabs-api-key', {
+            paramType: 'init-only',
+            value: config.aiApi.elevenLabsApiKey,
+            type: "SecureString",
+            description: "ElevenLabs APIのAPIキー",
+        });
+    }
+
+    if (config.aiApi.elevenLabsVoiceId !== undefined) {
+        parameters.elevenLabsVoiceId = ssmHelper.createParameter('/app/settings/elevenlabs-voice-id', {
+            paramType: 'managed',
+            value: config.aiApi.elevenLabsVoiceId,
+            type: "String",
+            description: "物語朗読に使うElevenLabsのVoice ID",
         });
     }
 

--- a/pulumi/lambda-ssm-init/components/config.ts
+++ b/pulumi/lambda-ssm-init/components/config.ts
@@ -48,6 +48,9 @@ export function loadConfig() {
             openaiApiKey: config.get("openaiApiKey") || "PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY",
             openaiSpeedModel: config.get("openaiSpeedModel") || "gpt-5.6-luna",
             openaiQualityModel: config.get("openaiQualityModel") || "gpt-5.6-terra",
+            // ElevenLabs（物語朗読用TTS）
+            elevenLabsApiKey: config.get("elevenLabsApiKey") || "PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY",
+            elevenLabsVoiceId: config.get("elevenLabsVoiceId") || "GxxMAMfQkDlnqjpzjLHH",
         }
     };
     

--- a/pulumi/lambda-ssm-init/index.ts
+++ b/pulumi/lambda-ssm-init/index.ts
@@ -50,6 +50,8 @@ export const outputs = {
             openaiApiKeyParameterName: applicationParams.openaiApiKey?.name,
             openaiSpeedModelParameterName: applicationParams.openaiSpeedModel?.name,
             openaiQualityModelParameterName: applicationParams.openaiQualityModel?.name,
+            elevenLabsApiKeyParameterName: applicationParams.elevenLabsApiKey?.name,
+            elevenLabsVoiceIdParameterName: applicationParams.elevenLabsVoiceId?.name,
         }
     }
 };


### PR DESCRIPTION
Closes #602

## 変更内容
物語朗読機能（ElevenLabs v3 TTS）のためのSSMパラメータを lambda-ssm-init に追加。

- `/app/settings/elevenlabs-api-key` — SecureString・**init-only**（プレースホルダーで作成し、デプロイ後に実キーを手動設定する運用。claude/openaiのAPIキーと同じ扱い）
- `/app/settings/elevenlabs-voice-id` — String・managed（既定値は朗読用voice「Kozy」= GxxMAMfQkDlnqjpzjLHH。声の差し替えはconfigまたはこの既定値の変更で）

## 適用
dev/prod 両スタックで lambda-ssm-init のデプロイジョブ実行後、elevenlabs-api-key に実キーを設定してください。