### PR TITLE
[pulumi] add: 英語朗読ボイス用SSMパラメータ（elevenlabs-voice-id-en）を追加

### DIFF
--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -332,11 +332,18 @@ Lambda API環境では、Claude APIとOpenAI APIを利用するための設定�
 - `/lambda-api/{env}/app/settings/openai-speed-model` - 高速処理用モデル（デフォルト: gpt-4.1-mini）
 - `/lambda-api/{env}/app/settings/openai-quality-model` - 高品質処理用モデル（デフォルト: gpt-4.1）
 
+**ElevenLabs設定（物語朗読用TTS）:**
+- `/lambda-api/{env}/app/settings/elevenlabs-api-key` - APIキー（SecureString）
+- `/lambda-api/{env}/app/settings/elevenlabs-voice-id` - 朗読ボイスID（デフォルト: GxxMAMfQkDlnqjpzjLHH）
+- `/lambda-api/{env}/app/settings/elevenlabs-voice-id-en` - 英語朗読ボイスID（**任意**。設定キー `elevenLabsVoiceIdEn` を設定した場合のみ作成。未設定時はAPI側が既存ボイスへフォールバック）
+
 ```bash
 # AI APIキーの設定（初回デプロイ後、AWSコンソールで実際のキーに更新）
 cd pulumi/lambda-ssm-init
 pulumi config set --secret claudeApiKey "your-actual-claude-api-key"
 pulumi config set --secret openaiApiKey "your-actual-openai-api-key"
+# 英語朗読を有効にする場合（英語圏開放時）
+pulumi config set elevenLabsVoiceIdEn "english-voice-id"
 pulumi up
 ```
 

--- a/pulumi/lambda-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.dev.yaml
@@ -33,3 +33,5 @@ config:
   # AI API設定（ElevenLabs API・物語朗読用TTS）
   lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"
+  # 英語朗読用ボイス（任意）。英語圏開放時にボイスIDを設定して pulumi up する
+  # lambda-ssm-init:elevenLabsVoiceIdEn: "REPLACE_WITH_ENGLISH_VOICE_ID"

--- a/pulumi/lambda-ssm-init/Pulumi.prod.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.prod.yaml
@@ -33,3 +33,5 @@ config:
   # AI API設定（ElevenLabs API・物語朗読用TTS）
   lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"
+  # 英語朗読用ボイス（任意）。英語圏開放時にボイスIDを設定して pulumi up する
+  # lambda-ssm-init:elevenLabsVoiceIdEn: "REPLACE_WITH_ENGLISH_VOICE_ID"

--- a/pulumi/lambda-ssm-init/components/applicationParameters.ts
+++ b/pulumi/lambda-ssm-init/components/applicationParameters.ts
@@ -21,6 +21,7 @@ interface AIApiConfig {
     openaiQualityModel?: string;
     elevenLabsApiKey?: string;
     elevenLabsVoiceId?: string;
+    elevenLabsVoiceIdEn?: string;
 }
 
 /**
@@ -116,6 +117,16 @@ export function createApplicationParameters(
             value: config.aiApi.elevenLabsVoiceId,
             type: "String",
             description: "物語朗読に使うElevenLabsのVoice ID",
+        });
+    }
+
+    // 英語朗読用ボイス（任意。未設定ならパラメータを作らず、API側は既存ボイスへフォールバック）
+    if (config.aiApi.elevenLabsVoiceIdEn !== undefined) {
+        parameters.elevenLabsVoiceIdEn = ssmHelper.createParameter('/app/settings/elevenlabs-voice-id-en', {
+            paramType: 'managed',
+            value: config.aiApi.elevenLabsVoiceIdEn,
+            type: "String",
+            description: "英語の物語朗読に使うElevenLabsのVoice ID",
         });
     }
 

--- a/pulumi/lambda-ssm-init/components/config.ts
+++ b/pulumi/lambda-ssm-init/components/config.ts
@@ -51,6 +51,8 @@ export function loadConfig() {
             // ElevenLabs（物語朗読用TTS）
             elevenLabsApiKey: config.get("elevenLabsApiKey") || "PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY",
             elevenLabsVoiceId: config.get("elevenLabsVoiceId") || "GxxMAMfQkDlnqjpzjLHH",
+            // 英語朗読用（任意・既定なし。未設定ならSSMパラメータ自体を作らない）
+            elevenLabsVoiceIdEn: config.get("elevenLabsVoiceIdEn"),
         }
     };
     

--- a/pulumi/lambda-ssm-init/index.ts
+++ b/pulumi/lambda-ssm-init/index.ts
@@ -52,6 +52,7 @@ export const outputs = {
             openaiQualityModelParameterName: applicationParams.openaiQualityModel?.name,
             elevenLabsApiKeyParameterName: applicationParams.elevenLabsApiKey?.name,
             elevenLabsVoiceIdParameterName: applicationParams.elevenLabsVoiceId?.name,
+            elevenLabsVoiceIdEnParameterName: applicationParams.elevenLabsVoiceIdEn?.name,
         }
     }
 };


### PR DESCRIPTION
Closes #604

## 概要

reflection-cloud-api のグループリフレクション英語対応（API側 PR #264 / #266）に対応するインフラ変更。英語朗読用のElevenLabsボイスIDを `lambda-ssm-init` で管理できるようにする。

## 変更内容

- 設定キー `elevenLabsVoiceIdEn`（**任意・既定なし**）を追加。設定した場合のみ `/app/settings/elevenlabs-voice-id-en`（String・managed）を作成し、パラメータ名をエクスポート
- `Pulumi.dev.yaml` / `Pulumi.prod.yaml` にコメントで設定例を追記
- `pulumi/README.md` にElevenLabs設定の節を追記（既存パラメータの記載漏れ補完含む）

## 影響範囲

- 未設定のままなら `pulumi up` してもリソース変更なし（パラメータは作られない）
- Lambda の IAM は `/lambda-api/{env}/*` のワイルドカード許可のため変更不要
- API側（config.service）は SSM `ELEVENLABS_VOICE_ID_EN` > env > フォールバックの順で解決（API PR #266）

## 運用手順（英語圏開放時）

1. ElevenLabsで英語ボイスを選定
2. `pulumi config set elevenLabsVoiceIdEn "<voice-id>"`（dev/prod各スタック）
3. `pulumi up`