### PR TITLE
[pulumi] update: dev環境の英語朗読ボイスIDを設定

### DIFF
--- a/pulumi/lambda-ssm-init/Pulumi.dev.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.dev.yaml
@@ -33,5 +33,5 @@ config:
   # AI API設定（ElevenLabs API・物語朗読用TTS）
   lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"
-  # 英語朗読用ボイス（任意）。英語圏開放時にボイスIDを設定して pulumi up する
-  # lambda-ssm-init:elevenLabsVoiceIdEn: "REPLACE_WITH_ENGLISH_VOICE_ID"
+  # 英語朗読用ボイス（Christopher - Calm Confident Narrator・2026-08-01選定）
+  lambda-ssm-init:elevenLabsVoiceIdEn: "jumP4YgL6qcL2qz3jaSF"


### PR DESCRIPTION
#604 の続き。英語朗読ボイスとして **Christopher - Calm Confident Narrator**（`jumP4YgL6qcL2qz3jaSF`・アメリカ英語・calm/deep/narrator系）をdevスタックに設定する。

- 選定理由: 落ち着いたナレーター声・標準アメリカ英語・非ネイティブにも聴き取りやすいことを確認済み
- devで実際の英語物語の朗読を生成して試聴確認後、prodにも設定する（別PR）
- 適用はJenkinsから実行（ユーザー作業）