### PR TITLE
[pulumi] update: prod環境の英語朗読ボイスIDを設定

### DIFF
--- a/pulumi/lambda-ssm-init/Pulumi.prod.yaml
+++ b/pulumi/lambda-ssm-init/Pulumi.prod.yaml
@@ -33,5 +33,5 @@ config:
   # AI API設定（ElevenLabs API・物語朗読用TTS）
   lambda-ssm-init:elevenLabsApiKey: PLACEHOLDER_PLEASE_UPDATE_WITH_ACTUAL_API_KEY
   lambda-ssm-init:elevenLabsVoiceId: "GxxMAMfQkDlnqjpzjLHH"
-  # 英語朗読用ボイス（任意）。英語圏開放時にボイスIDを設定して pulumi up する
-  # lambda-ssm-init:elevenLabsVoiceIdEn: "REPLACE_WITH_ENGLISH_VOICE_ID"
+  # 英語朗読用ボイス（Christopher - Calm Confident Narrator・dev試聴確認済み 2026-08-03）
+  lambda-ssm-init:elevenLabsVoiceIdEn: "jumP4YgL6qcL2qz3jaSF"


### PR DESCRIPTION
#604 の続き（最終）。devで実際の英語物語の朗読を生成して試聴確認済みの **Christopher - Calm Confident Narrator**（`jumP4YgL6qcL2qz3jaSF`）をprodスタックにも設定する。

- 適用はJenkinsから（ユーザー作業）
- prod Lambda側の英語対応コード（reflection-cloud-api develop→main昇格）が載るまでは、このパラメータは参照されないだけで無害